### PR TITLE
feat: Add configurable application branding

### DIFF
--- a/src/routes/WikiRoutes.js
+++ b/src/routes/WikiRoutes.js
@@ -160,8 +160,16 @@ class WikiRoutes {
       currentUser: userContext,
       user: userContext, // Add alias for consistency
       appName: configManager?.getProperty(
-        "amdwiki.application.name",
+        "amdwiki.applicationName",
         "amdWiki"
+      ),
+      applicationName: configManager?.getProperty(
+        "amdwiki.applicationName",
+        "amdWiki"
+      ),
+      faviconPath: configManager?.getProperty(
+        "amdwiki.faviconPath",
+        "/favicon.ico"
       ),
       pages: await pageManager.getAllPages(),
     };

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -4,8 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><% if (typeof pageName !== 'undefined' && pageName) { %><%= pageName %> | <% } %>amdWiki</title>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>📚</text></svg>">
+    <title><% if (typeof pageName !== 'undefined' && pageName) { %><%= pageName %> | <% } %><%= typeof applicationName !== 'undefined' ? applicationName : 'amdWiki' %></title>
+    <link rel="icon" href="<%= typeof faviconPath !== 'undefined' ? faviconPath : '/favicon.ico' %>">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="/css/style.css">
@@ -34,7 +34,7 @@
             <div class="row align-items-center py-2">
                 <div class="col-md-3">
                     <a class="navbar-brand" href="/">
-                        <span style="font-size: 1.5em;">📚</span> <strong>amdWiki</strong>
+                        <img src="<%= typeof faviconPath !== 'undefined' ? faviconPath : '/favicon.ico' %>" alt="Logo" style="height: 24px; width: 24px; margin-right: 8px;"> <strong><%= typeof applicationName !== 'undefined' ? applicationName : 'amdWiki' %></strong>
                     </a>
                 </div>
                 <div class="col-md-6">


### PR DESCRIPTION
## Summary

This PR adds support for configurable application branding through config properties, allowing deployments to customize the application name and favicon without code changes.

## Changes

### New Configuration Properties
- **`amdwiki.applicationName`**: Customize the application name (defaults to "amdWiki")
- **`amdwiki.faviconPath`**: Set a custom favicon path (defaults to "/favicon.ico")

### Bug Fix
- Fixed existing config property name from `amdwiki.application.name` to `amdwiki.applicationName` to match actual config usage

### Template Updates
- Updated `views/header.ejs`:
  - Page title now uses configurable application name
  - Favicon link uses configurable path instead of hardcoded emoji SVG
  - Navbar brand displays favicon image and application name

- Updated `src/routes/WikiRoutes.js`:
  - Added `applicationName` to template data
  - Added `faviconPath` to template data
  - Fixed config property name for application name

## Benefits

1. **Customizable Branding**: Deployments can set their own name and logo
2. **Backward Compatible**: Defaults to "amdWiki" and standard favicon if not configured
3. **Professional Appearance**: Uses actual favicon.ico instead of emoji
4. **Easy Configuration**: No code changes needed, just update config file

## Example Configuration

```json
{
  "amdwiki.applicationName": "The Fairways",
  "amdwiki.faviconPath": "/favicon.ico"
}
```

## Testing

Tested with custom configuration showing:
- Browser tab displays custom name and favicon
- Navbar shows custom logo and name
- All defaults work when properties not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)