### PR TITLE
docs: capture headless-deployment gotchas under docker/

### DIFF
--- a/docker/DEPLOYMENT.md
+++ b/docker/DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 Guide for deploying ngdpbase to various environments.
 
+> **For headless / containerized deploys** (Docker, Kubernetes), also read [`HEADLESS-DEPLOYMENT-NOTES.md`](./HEADLESS-DEPLOYMENT-NOTES.md). It captures gotchas — anchor Organization JSON-LD, theme/front-page/page-provider config, addons-path array form, Alpine `ndots:5` DNS, `npm ci --omit=dev` + husky, addon UUID validation — that aren't obvious from the default config alone.
+
 ## Table of Contents
 
 - [Local Deployment](#local-deployment)

--- a/docker/HEADLESS-DEPLOYMENT-NOTES.md
+++ b/docker/HEADLESS-DEPLOYMENT-NOTES.md
@@ -1,0 +1,210 @@
+# Headless deployment gotchas
+
+Notes captured during a production rollout of `ngdpbase` (with the `ve-geology` addon) to a k3s cluster on 2026-05-07. Each entry is a real symptom we hit, the root cause, and the fix — written so the next person doesn't have to rediscover them.
+
+These all surface specifically under `HEADLESS_INSTALL=true` (Docker / Kubernetes / any non-wizard install). The interactive `/install` path doesn't have these gaps because the wizard creates the missing records by hand.
+
+---
+
+## 1. Anchor Organization JSON-LD must be pre-supplied
+
+**Symptom.** Headless install creates the user and a Person record, but `/app/data/roles/` stays empty. Logged-in admin user resolves to `Anonymous|All` — no Edit button, no admin dashboard, ACL log shows `user=Anonymous` despite a successful login.
+
+**Root cause.** `UserManager.createDefaultAdmin` calls `applyRoleDiff(username, [], ['admin'])`, which calls `syncRoleAdd`. `syncRoleAdd`'s JSDoc:
+
+> Best-effort under degraded init: skips silently when … the install has no anchor org.
+
+`services/InstallService.ts` is explicit about this:
+
+> Headless installs do NOT seed the anchor org from config. Operators wanting a pre-seeded anchor org pre-supply the JSON-LD file alongside their custom config.
+
+**Fix.** Drop a JSON-LD `Organization` record into `INSTANCE_DATA_FOLDER/organizations/<name>.json` BEFORE the first boot, and point at it from `app-custom-config.json`:
+
+```json
+// app-custom-config.json
+"ngdpbase.application.organization.file": "geohazardwatch.json"
+```
+
+```json
+// data/organizations/geohazardwatch.json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://geohazardwatch.com",
+  "name": "GeoHazardWatch",
+  "url": "https://geohazardwatch.com"
+}
+```
+
+In Kubernetes, both files can ship as keys in the same ConfigMap, mounted via two `subPath` mounts (one to `data/config/app-custom-config.json`, one to `data/organizations/<name>.json`).
+
+---
+
+## 2. `createDefaultAdmin` only runs when `users.size === 0`
+
+**Symptom.** A previous failed boot left a `users.json` on the volume. Even after fixing the cause of the original failure (e.g., missing Organization, wrong base image), bringing the pod back up with the corrected config does NOT re-create the admin or its Person/Role records.
+
+**Root cause.** `UserManager.initialize()` only triggers `createDefaultAdmin` when the user provider returns zero users. Any pre-existing user blocks it.
+
+**Fix.** Scale to zero, delete `users.json` (and any orphaned Person records left over from the earlier boot), scale back up. New admin will be created cleanly.
+
+```bash
+kubectl -n <ns> scale deploy/<name> --replicas=0
+kubectl -n <ns> wait --for=delete pod -l app=<name>
+sudo rm /path/to/data/users/users.json
+sudo rm /path/to/data/persons/<orphan-uuid>.json   # if applicable
+kubectl -n <ns> scale deploy/<name> --replicas=1
+```
+
+The user will be reset to `admin` / `admin123` for the first login. Pages, attachments, and search index survive — only the user account is rebuilt.
+
+---
+
+## 3. Theme, front-page, page-provider are not auto-set by addons
+
+**Symptom.** Site defaults to the bundled `default` theme, redirects `/` to `Welcome`, and uses `filesystemprovider` for page storage — even when an addon is installed and active. The addon can't override these.
+
+**Root cause.** These are operator-owned settings. Addons can register pages, plugins, routes, themes (the asset), but they do not (and intentionally cannot) override what the operator has chosen for theme, front page, or storage provider.
+
+**Fix.** Set them explicitly in `app-custom-config.json`:
+
+```json
+"ngdpbase.theme.active":   "volcano",
+"ngdpbase.front-page":     "volcanoes-and-earthquakes",
+"ngdpbase.page.provider":  "versioningfileprovider"
+```
+
+Notes:
+
+- **`theme.active`** — folder name under `/app/themes/`. Must exist in the image.
+- **`front-page`** — page slug to redirect `/` to. Must exist as a seeded page or the redirect 404s.
+- **`page.provider`** — `versioningfileprovider` is what the editing UI is built around (history, comments, diffs). The default `filesystemprovider` is more restricted; expect missing UI affordances. Switching providers triggers a one-time on-disk migration on first boot (you'll see `Migrated N/N pages` in the log).
+
+---
+
+## 4. `addons-path`: string replaces, array supplements
+
+**Symptom.** Setting `ngdpbase.managers.addons-manager.addons-path` to a single path (intending to add an external addon dir) silently kills the built-in addons. None of `calendar`, `forms`, `journal`, `elasticsearch` get discovered.
+
+**Root cause.** From `AddonsManager.ts`:
+
+```ts
+this.addonsPaths = Array.isArray(raw)
+  ? (raw as string[]).map(String)
+  : [String(raw)];
+```
+
+A string ends up as a single-entry array. `./addons` (the default) is replaced, not appended.
+
+**Fix.** Use the array form to scan multiple directories:
+
+```json
+"ngdpbase.managers.addons-manager.addons-path": [
+  "/app/addons",
+  "/opt/your-addon-repo/addons"
+]
+```
+
+---
+
+## 5. Alpine musl + k8s `ndots:5` breaks external DNS
+
+**Symptom.** Pods (e.g., a CronJob calling external APIs) fail to resolve external hostnames. `nslookup webservices.example.com` from inside the pod succeeds (it queries the cluster DNS server directly), but `curl https://webservices.example.com/` returns `Could not resolve host`. Node `fetch()` returns the bare `fetch failed` error.
+
+**Root cause.** The base image is Alpine, which ships musl libc. Kubernetes' default `/etc/resolv.conf` includes `options ndots:5`, telling libc to expand the search domain list before treating any name with fewer than 5 dots as absolute. musl's parallel A/AAAA queries to CoreDNS misfire on this expansion in some clusters.
+
+**Confirmation test.** A trailing-dot FQDN (`https://webservices.example.com./`) skips the search-list dance and works — that proves the diagnosis.
+
+**Fix.** Override `ndots` to `1` on the pod spec:
+
+```yaml
+spec:
+  template:
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+```
+
+Apply to both the Deployment and any Job/CronJob that makes external HTTPS calls. Cluster-internal short names (`servicename`) still resolve via the search list because they have zero dots.
+
+---
+
+## 6. `npm ci --omit=dev` fails on `prepare` / husky
+
+**Symptom.** Image build fails at `RUN npm ci --omit=dev` with:
+
+```
+sh: husky: not found
+npm error code 127
+npm error command sh -c husky install
+```
+
+**Root cause.** `package.json`'s `prepare` lifecycle script runs `husky install`. Under `--omit=dev`, husky (a devDependency) isn't installed, but the lifecycle script still fires.
+
+**Fix.** Add `--ignore-scripts` to the `npm ci` invocation. We don't need git hooks inside a runtime container.
+
+```dockerfile
+RUN npm ci --omit=dev --ignore-scripts
+```
+
+---
+
+## 7. `AddonsManager` validates seed page UUIDs strictly
+
+**Symptom.** Boot logs show `[AddonsManager] Skipping <addon>/pages/<file>.md — missing or invalid uuid in frontmatter` for every seed page. Wiki has zero addon content.
+
+**Root cause.** `AddonsManager.ts` validates against a strict v4 regex:
+
+```ts
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+```
+
+Placeholder UUIDs containing non-hex characters (e.g. `a1b2c3d4-0001-4000-8000-veXgeologyXX`) pass the structural shape check by eye but fail the regex. The pages get silently skipped.
+
+**Fix.** Use real UUID v4 values in the `uuid` frontmatter on every seed page:
+
+```bash
+node -e "console.log(require('crypto').randomUUID())"
+```
+
+The destination filename in `data/pages/` is `{uuid}.md` — the source filename is ignored. Use a fresh UUID per page and never copy them between addons (cross-addon UUID collisions cause `[AddonsManager] Page conflict` warnings and silent skips).
+
+See `docs/platform/addon-development-guide.md` UUID requirements section for the full rules.
+
+---
+
+## 8. Use a stable session secret
+
+**Symptom.** Logged-in users get bumped to anonymous after every pod restart. Browser still holds a session cookie, but the server treats them as Anonymous.
+
+**Root cause.** Without `SESSION_SECRET` set, `ngdpbase` generates a random secret on each pod start. Existing cookies' HMAC signatures stop validating against the new secret.
+
+**Fix.** Pass a stable secret via env var, sourced from a Kubernetes `Secret` (ideally SOPS-encrypted in your GitOps repo):
+
+```yaml
+env:
+  - name: SESSION_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: <name>-secrets
+        key: session-secret
+```
+
+Generate once: `openssl rand -base64 32`. Rotate when needed; rotation invalidates all existing sessions.
+
+---
+
+## Recommended deploy order
+
+For a clean first deploy under HEADLESS_INSTALL=true:
+
+1. Build/publish your image (with the Dockerfile fixes from §6).
+2. Author the `ConfigMap` containing both `app-custom-config.json` (with theme, front-page, page provider, addons-path, organization.file) AND the Organization JSON-LD (§1).
+3. Author the Deployment with `dnsConfig.options.ndots: "1"` (§5), the SESSION_SECRET reference (§8), and the two ConfigMap subPath mounts.
+4. Apply, wait for first pod Ready. The boot log should show `OrganizationManager initialized (1 orgs)`, `Created Person record for admin`, `Created default admin user`, and an Add-on loaded line.
+5. Verify `/app/data/roles/admin.json` exists and its `member` array references the same UUID as `/app/data/persons/<uuid>.json`.
+6. Log in as `admin` / `admin123` and change the password immediately.
+
+If steps 5-6 don't work, you've probably hit one of §1, §2, or §3 — re-check the ConfigMap and use the cleanup recipe from §2 to re-trigger `createDefaultAdmin`.

--- a/docker/k8s/README.md
+++ b/docker/k8s/README.md
@@ -2,6 +2,8 @@
 
 Deploy ngdpbase to Kubernetes.
 
+> **Before you deploy:** read [`../HEADLESS-DEPLOYMENT-NOTES.md`](../HEADLESS-DEPLOYMENT-NOTES.md) — it captures real gotchas hit during a production rollout (anchor Organization, theme/front-page/page-provider config, Alpine `ndots:5` DNS, husky `prepare` script, addon UUID validation). The "Recommended deploy order" at the bottom is the short version of this README plus those gotchas.
+
 ## Quick Start
 
 ```bash

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -2,6 +2,28 @@
 
 AI agent session tracking. See [CHANGELOG.md](./CHANGELOG.md) for version history.
 
+## 2026-05-07-06
+
+- Agent: Claude Opus 4.7
+- Subject: Document headless-deployment gotchas discovered during the geohazardwatch (`jwilleke/geohazardwatch`) k3s rollout
+- Current Issue: none (docs only)
+- Work Done:
+  - Added `docker/HEADLESS-DEPLOYMENT-NOTES.md` capturing eight real gotchas hit during the rollout, each with symptom / root cause / fix:
+    1. Anchor `Organization` JSON-LD must be pre-supplied (`InstallService` does not seed it; without it `applyRoleDiff` silently skips role assignment and admin resolves to `Anonymous|All`)
+    2. `createDefaultAdmin` only runs when `users.size === 0` — must delete `users.json` to force re-creation
+    3. `theme.active`, `front-page`, `page.provider` are not auto-set by addons — operator must declare in `app-custom-config.json`
+    4. `addons-manager.addons-path` as a string REPLACES the default; use array form to scan multiple dirs
+    5. Alpine musl + k8s `ndots:5` breaks external DNS via `getaddrinfo`; fix with pod `dnsConfig.options.ndots: "1"`
+    6. `npm ci --omit=dev` triggers `prepare` lifecycle which fails on missing husky devDep — add `--ignore-scripts`
+    7. `AddonsManager` validates seed page UUIDs strictly against UUID v4 regex; placeholder UUIDs are silently skipped
+    8. `SESSION_SECRET` must be stable across pod restarts or sessions don't survive
+  - Added link callouts from `docker/DEPLOYMENT.md` and `docker/k8s/README.md`.
+- Files Modified:
+  - `docker/HEADLESS-DEPLOYMENT-NOTES.md` (new)
+  - `docker/DEPLOYMENT.md`
+  - `docker/k8s/README.md`
+  - `docs/project_log.md` (this file)
+
 ## 2026-05-07-05
 
 - Agent: Claude


### PR DESCRIPTION
## Summary

While doing a fresh k3s rollout of [`jwilleke/geohazardwatch`](https://github.com/jwilleke/geohazardwatch) (ngdpbase + the ve-geology addon) today, we hit eight real failure modes that aren't obvious from `docker/DEPLOYMENT.md` or `docker/k8s/README.md`. This PR captures them so the next person doesn't have to re-discover.

New file: `docker/HEADLESS-DEPLOYMENT-NOTES.md`. Each entry has **symptom, root cause, fix**, with `ngdpbase` source references where helpful.

| # | Gotcha | Where it bit us |
|---|---|---|
| 1 | Anchor `Organization` JSON-LD must be pre-supplied | `applyRoleDiff` silently skipped role assignment; admin resolved to `Anonymous|All` |
| 2 | `createDefaultAdmin` only runs when `users.size === 0` | A failed first boot left a `users.json` that blocked re-creation after the fix |
| 3 | `theme.active`, `front-page`, `page.provider` not auto-set by addons | Wiki shipped with `default` theme + `Welcome` redirect + `filesystemprovider` |
| 4 | `addons-path` string replaces default; array form is needed | Built-in addons stopped loading when external addon path was set |
| 5 | Alpine musl + k8s `ndots:5` breaks `getaddrinfo` | Initial data-import job failed with bare `fetch failed` |
| 6 | `npm ci --omit=dev` runs the `prepare` (husky) lifecycle | Image build failed exit 127 |
| 7 | `AddonsManager` validates seed page UUIDs against strict v4 regex | Placeholder UUIDs were silently skipped; wiki had zero addon content |
| 8 | `SESSION_SECRET` must be stable across pod restarts | Sessions invalidated on every pod recycle |

Also adds a one-line callout to `docker/DEPLOYMENT.md` and `docker/k8s/README.md` pointing readers at the new file before they start.

## Why these belong upstream

All eight apply to **any** ngdpbase headless deploy, not just the geohazardwatch instance. Most also apply to plain Docker, not only Kubernetes. Capturing them under `docker/` keeps them with the existing deployment docs so they're discovered together.

## What's NOT in this PR

- No code changes. Pure docs.
- The geohazardwatch-specific manifest fixes that surfaced these are in `jwilleke/mj-infra-flux` — see PRs #51 (DNS), #52 (theme/front-page/provider), #54 (anchor org).

## Test plan

- [ ] Render `docker/HEADLESS-DEPLOYMENT-NOTES.md` on GitHub — links resolve, code blocks lint clean.
- [ ] Cross-check the source quotes (e.g., `services/InstallService.ts:637`, `UserManager.ts:255-260`) against current master.
- [ ] No code is changed; existing tests should pass unchanged (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)