### PR TITLE
fix(docker): copy themes/ into runtime image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,6 +66,12 @@ COPY --from=builder /app/views ./views
 # Copy public assets
 COPY --from=builder /app/public ./public
 
+# Copy themes (core CSS variables, default/flatly/fairways/volcano theme dirs).
+# Required at runtime — the page header references /themes/core.css and
+# /themes/<active>/theme.css. Without this, the runtime falls back to a
+# regenerated default.css and any non-default theme returns 404.
+COPY --from=builder /app/themes ./themes
+
 # Copy required-pages (system templates)
 COPY --from=builder /app/required-pages ./required-pages
 


### PR DESCRIPTION
## Summary

The published runtime image (`ghcr.io/jwilleke/ngdpbase:3.10.1`) is missing `/app/themes` entirely. `TemplateManager` regenerates a fallback `default.css` on boot, but `/themes/core.css`, `/themes/core-variables-empty.css`, and every theme directory (`default/`, `flatly/`, `fairways/`, `volcano/`) are absent.

## Symptom

Hit on the geohazardwatch deployment at `https://geohazardwatch.nerdsbythehour.com/`:

```
GET /themes/core.css                  → 404
GET /themes/core-variables-empty.css  → 404
GET /themes/volcano/theme.css         → 404
```

`ngdpbase.theme.active: "volcano"` in `app-custom-config.json` had no effect because the directory wasn't there. Maps and other Leaflet-based plugin output rendered with incorrect sizing because the core CSS variables that define container/box rules never loaded.

## Cause

`docker/Dockerfile` Stage 2 (runtime) copies `dist`, `views`, `public`, `required-pages`, `addons`, `resources`, and `config/app-default-config.json` — but doesn't copy `themes/`.

## Fix

```diff
 # Copy public assets
 COPY --from=builder /app/public ./public

+# Copy themes (core CSS variables, default/flatly/fairways/volcano theme dirs).
+COPY --from=builder /app/themes ./themes
+
 # Copy required-pages (system templates)
 COPY --from=builder /app/required-pages ./required-pages
```

## Test plan

- [ ] Build the image locally: `docker build -f docker/Dockerfile -t test .` — expect `themes/` to be in the resulting image.
- [ ] `docker run --rm test ls /app/themes` should list `core.css`, `core-variables-empty.css`, `default.css`, `default/`, `flatly/`, `fairways/`, `volcano/`, `plugins/`.
- [ ] After publishing a new release, downstream images (e.g. `ghcr.io/jwilleke/geohazardwatch`) inheriting from this base should serve `/themes/core.css` (200) and `/themes/<active>/theme.css` (200).
- [ ] Existing `theme.active` setting in `app-custom-config.json` should now actually apply visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)