### PR TITLE
chore(deps): bump uuid 9.0.1 → 14.0.0 in root + addons/calendar + addons/forms

### DIFF
--- a/addons/calendar/package-lock.json
+++ b/addons/calendar/package-lock.json
@@ -11,7 +11,7 @@
         "date-fns": "^3.0.0",
         "express": "^5.2.1",
         "ts-ics": "^2.4.4",
-        "uuid": "^9.0.1"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -971,16 +971,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/addons/calendar/package.json
+++ b/addons/calendar/package.json
@@ -8,7 +8,7 @@
     "date-fns": "^3.0.0",
     "express": "^5.2.1",
     "ts-ics": "^2.4.4",
-    "uuid": "^9.0.1"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/addons/forms/package-lock.json
+++ b/addons/forms/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "^5.2.1",
-        "uuid": "^9.0.1",
+        "uuid": "^14.0.0",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -945,16 +945,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/addons/forms/package.json
+++ b/addons/forms/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "express": "^5.2.1",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngdpbase",
-  "version": "3.27.0",
+  "version": "3.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngdpbase",
-      "version": "3.27.0",
+      "version": "3.32.0",
       "license": "ISC",
       "dependencies": {
         "@elastic/elasticsearch": "^8.19.1",
@@ -48,7 +48,7 @@
         "showdown-footnotes": "^2.1.2",
         "tslib": "^2.8.1",
         "turndown": "^7.2.2",
-        "uuid": "^9.0.1",
+        "uuid": "^14.0.0",
         "winston": "^3.17.0"
       },
       "devDependencies": {
@@ -10510,16 +10510,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "showdown-footnotes": "^2.1.2",
     "tslib": "^2.8.1",
     "turndown": "^7.2.2",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.0",
     "winston": "^3.17.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Sibling bumps to Dependabot's #768 (which only covers `addons/journal`). Closes Dependabot alerts **GHSA-w5hq-g745-h8pq** for the three remaining manifest paths:

- root `package.json` — alert #117
- `addons/calendar/package.json` — alert #119
- `addons/forms/package.json` — alert #118
- (`addons/journal/package.json` — alert #116 — covered by #768)

uuid v14 fixes the GHSA: `v3()` / `v5()` / `v6()` did not validate that writes would remain within the bounds of a caller-supplied buffer, allowing out-of-bounds writes when an invalid `offset` was provided. v14 now throws `RangeError` if `offset < 0` or `offset + 16 > buf.length`.

## Breaking changes — irrelevant to this codebase

- v14 requires node@20+ and expects `crypto` to be a global. Repo's `engines.node` is already `">=24.0.0"`; node@24 has global crypto. **Compatible.**
- v3/v5/v6 with offset args now throws on out-of-bounds. Grep across `src/` + `addons/*/src` found **no call sites** passing buffer/offset args to v3/v5/v6. Our usage is exclusively `v4()` (random), which has no breaking change.

## Test plan

- [x] `npm run build` — exits clean
- [x] `npm test` — 5875/5875 unit pass
- [x] `npm run test:e2e` — 72/72 pass on jimstest
- [x] `jq -r '.packages["node_modules/uuid"].version' package-lock.json` returns `14.0.0` (same for `addons/calendar` and `addons/forms` lockfiles)
- [ ] Operator merges; the 3 Dependabot alerts (#117 / #118 / #119) auto-close on push to master

After merge of this PR + #768, all four `uuid` alerts are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)