### PR TITLE
fix(security): bump undici 6.24.1 → 6.27.0 in addons/elasticsearch

### DIFF
--- a/addons/elasticsearch/package-lock.json
+++ b/addons/elasticsearch/package-lock.json
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
Fixes #844

Lockfile-only refresh of transitive undici in `addons/elasticsearch` (manifest range `^6.21.1` already permits 6.27.0; ran `npm update undici` in the addon dir).

Resolves Dependabot alerts:
- 157 GHSA-vxpw-j846-p89q (high) — WebSocket client DoS via fragment count bypass
- 158 GHSA-p88m-4jfj-68fv (medium) — HTTP header injection via Set-Cookie percent-decoding
- 159 GHSA-g8m3-5g58-fq7m (low) — Set-Cookie SameSite downgrade
- 156 GHSA-35p6-xmwp-9g52 (low) — HTTP response queue poisoning via keep-alive reuse

Tests: `vitest run addons/elasticsearch` — 53 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)