### PR TITLE
fix(security): bump js-yaml 3.14.2 → 3.15.0 (gray-matter)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6005,9 +6005,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -6550,9 +6550,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes #831

Lockfile-only refresh: upstream shipped patched js-yaml 3.15.0, and the existing scoped override `"gray-matter": { "js-yaml": "^3.14.1" }` already permits it. Ran `npm update js-yaml`; also moves 4.x instances (eslint, pm2) 4.2.0 → 4.3.0 within the `^4.2.0` override.

Resolves Dependabot alert 170 — GHSA-h67p-54hq-rp68 (medium), quadratic-complexity DoS in merge-key handling via repeated aliases.

Tests: full suite — 250 files, 6233 passed / 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)