### PR TITLE
docs(media): document Reindex vs Rebuild + troubleshooting (#814)

### DIFF
--- a/required-pages/e36d72ac-3d76-4fc8-9e55-47dfeb09d456.md
+++ b/required-pages/e36d72ac-3d76-4fc8-9e55-47dfeb09d456.md
@@ -9,7 +9,7 @@ user-keywords:
   - gallery
   - documentation
 slug: media-management
-lastModified: '2026-04-23T00:00:00.000Z'
+lastModified: '2026-07-15T00:00:00.000Z'
 author: system
 editor: system
 ---
@@ -30,8 +30,10 @@ User guide for the Media Management feature in [{$applicationname}].
 9. [Thumbnails|#thumbnails]
 10. [Supported File Formats|#supported-file-formats]
 11. [Admin: Configuring and Scanning|#admin-configuring-and-scanning]
-12. [Configuration Reference|#configuration-reference]
-13. [Limitations|#limitations]
+12. [Reindex vs Rebuild|#reindex-vs-rebuild]
+13. [Why Isn't a File Showing?|#why-isnt-a-file-showing]
+14. [Configuration Reference|#configuration-reference]
+15. [Limitations|#limitations]
 
 ---
 
@@ -381,18 +383,14 @@ Restart the server after changing these settings.
 
 ### Triggering a scan
 
-**URL:** `GET /admin/media`
-
-The admin media page shows the current index statistics (number of years indexed, year range) and a **Trigger Rescan** button.
-
-Clicking **Trigger Rescan** sends a `POST /admin/media/rescan` request. The scan runs synchronously and the page shows a summary of the result:
+The **Admin Dashboard** (`/admin`) Media Management card provides two buttons — **Reindex Media** and **Rebuild Media** — with a question-mark link next to each pointing back to this page. Both run as **background jobs** with live progress reporting; you can keep using the site while they run. When a job finishes it shows a summary:
 
 - **Scanned** — total files examined
 - **Added** — new items added to the index
 - **Updated** — existing items whose file content changed
 - **Errors** — files that could not be processed (check the server log for details)
 
-For very large libraries the scan may take several minutes. The browser will wait for the response.
+Anomalies (missing folders, capture-date gaps, processing errors) are also surfaced to `/admin/notifications`.
 
 ### Automatic background scans
 
@@ -403,6 +401,40 @@ ngdpbase.media.scaninterval = 3600000
 ```
 
 Set to `0` to disable background scanning.
+
+The scheduled scan is **incremental**: files whose modification time is unchanged since the last scan are skipped, so it completes in seconds even on large libraries. New files therefore appear in the Media Manager within one interval — up to an hour by default.
+
+---
+
+## Reindex vs Rebuild
+
+The two admin operations differ in how much existing state they trust:
+
+%%table-striped
+|| || Reindex Media || Rebuild Media ||
+| What it does | Re-walks all configured folders and re-reads metadata for every file, even when the modification time is unchanged | Deletes the entire index (including the persisted `media-index.json`), then scans everything from scratch |
+| Existing index | Kept; entries are updated in place | Discarded before the scan starts |
+| Use when | New files aren't appearing; you edited EXIF/IPTC/XMP metadata (keywords, dates) in place; you replaced a file's content but kept its timestamp | The index seems corrupt or inconsistent; entries for long-deleted files linger; after an index schema change |
+| Cost | Full metadata read of the whole library | Same, plus the browse pages are empty until the rebuild finishes |
+/%
+
+Rule of thumb: start with **Reindex**. Reach for **Rebuild** only when the index itself is suspect — while it runs, year browsing and search return incomplete results.
+
+(The hourly background scan is a third, lighter tier: it skips files with unchanged modification times, so it only picks up new and touched files.)
+
+---
+
+## Why Isn't a File Showing?
+
+A file that exists on disk can legitimately be absent from the Media Manager for one of these reasons — check them in order:
+
+1. **It hasn't been scanned yet.** New files appear only after the next background scan (up to one hour by default) or a manual **Reindex Media**.
+2. **It's an alternate format of another file.** When the *same directory* contains several files with the *same base name* (e.g. `IMG_1234.jpg` and `IMG_1234.png`), only the highest-priority format gets its own entry; the others are attached to it as alternates. Priority order: `jpg`, `jpeg`, `png`, `webp`, `tiff`, `tif`, `bmp`, `heic`, `heif`, then camera RAW formats.
+3. **It carries the `ngdpbaseignore` keyword.** Any file whose EXIF/IPTC/XMP keyword list contains `ngdpbaseignore` is deliberately excluded (and evicted from the index if previously indexed). Remove the keyword and Reindex to restore it.
+4. **A `.ngdpbaseignore` file matches it.** A directory may contain a `.ngdpbaseignore` file with glob patterns (one per line, `#` comments allowed); matching files are skipped, and patterns ending in `/` skip whole subdirectories.
+5. **Its extension isn't indexed.** See [Supported File Formats|#supported-file-formats] and the `ngdpbase.media.extensions` setting.
+6. **It's in an ignored or hidden location.** Directories named in `ngdpbase.media.ignoredirs` (default `.dtrash`, `.ts`), hidden files/directories (name starting with `.`), and anything deeper than `ngdpbase.media.maxdepth` (default 5 levels below a configured folder) are skipped.
+7. **The scan hit an error on it.** Check the job summary's error count and the server log.
 
 ---
 
@@ -417,7 +449,6 @@ All settings live in the `ngdpbase.media.*` namespace.
 | `ngdpbase.media.maxdepth` | `5` | Maximum directory depth (0 = unlimited) |
 | `ngdpbase.media.scaninterval` | `3600000` | Background rescan interval in ms |
 | `ngdpbase.media.ignoredirs` | `[".dtrash", ".ts"]` | Directory names to skip during scan |
-| `ngdpbase.media.ignorefiles` | `[".photoviewignore", ".plexignore"]` | Sentinel files that exclude a directory |
 | `ngdpbase.media.extensions` | *(see Supported File Formats)* | File extensions to index (overrides built-in list) |
 | `ngdpbase.media.index.file` | *(data dir)* | Absolute path to `media-index.json` |
 | `ngdpbase.media.thumbnail.dir` | *(data dir)* | Absolute path to thumbnail cache directory |
@@ -425,10 +456,10 @@ All settings live in the `ngdpbase.media.*` namespace.
 | `ngdpbase.media.metadata.priority` | `["EXIF","IPTC","XMP"]` | Metadata extraction priority |
 /%
 
-### ignoredirs and ignorefiles
+### ignoredirs and .ngdpbaseignore
 
 - **`ignoredirs`** — any directory whose **name** exactly matches an entry in this list is skipped entirely (and its children are not scanned).
-- **`ignorefiles`** — if a directory **contains** a file with one of these names, the entire directory (and its children) is skipped. This is compatible with the `.photoviewignore` and `.plexignore` conventions used by other photo management tools.
+- **`.ngdpbaseignore`** — a per-directory ignore file containing glob patterns, one per line (blank lines and `#` comments are skipped). Matching files are excluded from the index; patterns ending in `/` exclude matching subdirectories and everything below them. See [Why Isn't a File Showing?|#why-isnt-a-file-showing].
 
 ---
 

--- a/views/admin-dashboard.ejs
+++ b/views/admin-dashboard.ejs
@@ -411,14 +411,14 @@
                             <button id="dashboard-rescan-btn" class="btn btn-outline-secondary btn-sm" onclick="dashboardMediaRescan()">
                                 <i class="fas fa-sync"></i> Reindex Media
                             </button>
-                            <a href="/view/media" class="text-muted small" title="Documentation" target="_blank"><i class="fas fa-question-circle"></i></a>
+                            <a href="/view/media-management#reindex-vs-rebuild" class="text-muted small" title="Reindex vs Rebuild — what's the difference?" target="_blank"><i class="fas fa-question-circle"></i></a>
                         </span>
 
                         <span class="d-inline-flex align-items-center gap-1">
                             <button id="dashboard-rebuild-btn" class="btn btn-warning btn-sm" onclick="dashboardMediaRebuild()">
                                 <i class="fas fa-database"></i> Rebuild Media
                             </button>
-                            <a href="/view/media" class="text-muted small" title="Documentation" target="_blank"><i class="fas fa-question-circle"></i></a>
+                            <a href="/view/media-management#reindex-vs-rebuild" class="text-muted small" title="Reindex vs Rebuild — what's the difference?" target="_blank"><i class="fas fa-question-circle"></i></a>
                         </span>
 
                         <span class="d-inline-flex align-items-center gap-1">


### PR DESCRIPTION
Addresses the documentation half of #814 (triage found no indexing bug — see issue comments).

**Media Management required-page** (`/view/media-management`):
- New **Reindex vs Rebuild** section — comparison table (what each operation does, what it trusts, when to use which) plus the hourly incremental background scan as the third tier.
- New **Why Isn't a File Showing?** section — 7-point checklist: scan interval, same-stem alternate-format dedup (#515), EXIF `ngdpbaseignore` keyword, `.ngdpbaseignore` files, extensions, ignoredirs/maxdepth/hidden, scan errors.
- Fixed stale content: admin scans are background jobs now (page claimed synchronous); removed `ngdpbase.media.ignorefiles` (.photoviewignore/.plexignore) from the config reference — documented but never implemented; replaced with the actual `.ngdpbaseignore` mechanism.

**Admin dashboard**: the question-mark links beside Reindex Media / Rebuild Media now deep-link to `/view/media-management#reindex-vs-rebuild` instead of the generic media page.

Verified on jimstest: page deployed (live copy was unmodified — clean sync), both anchors render, tables render, dashboard links updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)