### PR TITLE
chore(security): Trivy dedup pass — .trivyignore for forms-addon false positives

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -145,6 +145,7 @@ jobs:
           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.DOCKER_IMAGE_NAME }}:latest
           format: 'sarif'
           output: 'trivy-results.sarif'
+          trivyignores: '.trivyignore'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,8 @@
+# Trivy false positives — name collision.
+#
+# app/addons/forms/package.json is the ngdpbase forms ADDON (private,
+# name "forms", version 1.0.0), not the npm "forms" library. Trivy matches
+# by package name and flags the npm library's advisories against it.
+CVE-2021-23388
+CVE-2017-16015
+NSWG-ECO-158

--- a/TODO.md
+++ b/TODO.md
@@ -67,5 +67,5 @@ Generated priority mirror of open GitHub issues — the `P0` / `P1` / `P2` / `de
 
 ## Scanner-alert notes (not bulk-bridged)
 
-- ~23 open code-scanning alerts remain, nearly all in container-image paths (`usr/local/lib/node_modules/npm/...`, `app/node_modules/...`) — duplicative of Dependabot / base-image updates; still flagged for a dedup/triage pass (unchanged since 2026-06-16).
+- Code-scanning (Trivy image scan) dedup pass done 2026-07-15: of 22 open alerts, 3 are false positives (name collision — the forms addon vs the npm `forms` library; `.trivyignore` added, dismiss pending), 18 are staleness (image last built 2026-06-08 at v3.49.0, before the June-16 dep wave — uuid/pm2/npm-bundled all fixed or floating in current sources; next release build clears them), 1 (pm2 CVE-2025-5891, low) has no upstream fix and may re-flag after rebuild.
 - Markdown Lint CI: fix open in PR #849 (CI globs now honor .markdownlintignore, real violations fixed, action bumped v19 → v24); red on master until merged.


### PR DESCRIPTION
Dedup/triage of the 22 open container-image (Trivy) code-scanning alerts, as flagged in TODO's scanner-notes since 2026-06-16.

| Group | Count | Disposition |
|---|---|---|
| `app/addons/forms/package.json` matched against the npm **forms** library | 3 | **False positive** — name collision with the private forms addon (`name: forms, version: 1.0.0`). `.trivyignore` added (CVE-2021-23388, CVE-2017-16015, NSWG-ECO-158) and wired into the docker-build Trivy step; alerts to be dismissed as false-positive. |
| `app/node_modules` uuid ×4, pm2 ×1 | 5 | **Stale image** — built 2026-06-08 (v3.49.0), before the June-16 dep wave. Current lockfiles resolve uuid 14.0.0 (= fixed version) and pm2 7.0.1. Next release build clears them. |
| `usr/local/lib/node_modules/npm/...` (tar, minimatch, glob, cross-spawn, brace-expansion, diff) | 13 | **Base image** — npm CLI bundled in `node:24-alpine`; floating tag pulls a patched npm on next build. Not repo-actionable. |
| pm2 CVE-2025-5891 (low) | (1 of the 5 above) | No upstream fixed version; may re-flag after rebuild — accept/watch. |

No dependency changes; repo lockfiles were already clean (verified against Dependabot, which shows only showdown #599).

🤖 Generated with [Claude Code](https://claude.com/claude-code)