### PR TITLE
fix(import): surface real preview errors instead of 'Unknown error' (#815)

### DIFF
--- a/src/managers/ImportManager.ts
+++ b/src/managers/ImportManager.ts
@@ -336,7 +336,7 @@ class ImportManager extends BaseManager {
       result.success = false;
       result.errors.push({
         file: options.sourceDir,
-        message: 'Source path does not exist'
+        message: 'Source path does not exist (paths are resolved on the server, not your browser\'s machine)'
       });
       result.durationMs = Date.now() - startTime;
       return result;

--- a/src/routes/WikiRoutes.ts
+++ b/src/routes/WikiRoutes.ts
@@ -9385,13 +9385,22 @@ ${panes}
         generateUUIDs: generateUUIDs !== false
       });
 
+      // On failure, surface the per-file messages as a top-level `error` too —
+      // the dialog in admin-import.ejs only shows `error` (#815).
+      const errorSummary = !result.success && result.errors.length
+        ? result.errors.map((e: { file?: string; message: string }) =>
+          e.file ? `${e.file}: ${e.message}` : e.message
+        ).slice(0, 5).join('; ')
+        : undefined;
+
       return res.json({
         success: result.success,
         files: result.files,
         converted: result.converted,
         skipped: result.skipped,
         failed: result.failed,
-        errors: result.errors
+        errors: result.errors,
+        ...(errorSummary ? { error: errorSummary } : {})
       });
     } catch (err: unknown) {
       logger.error('Error previewing import:', err);

--- a/src/routes/__tests__/WikiRoutes.importPreview.test.ts
+++ b/src/routes/__tests__/WikiRoutes.importPreview.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for WikiRoutes.adminImportPreview() — POST /admin/import/preview (#815).
+ *
+ * The import dialog in admin-import.ejs only displays a top-level `error`
+ * string, but ImportManager failures arrive as an `errors[]` array — so every
+ * preview failure surfaced as "Unknown error". The handler now composes a
+ * top-level `error` summary from `errors[]` whenever the result is
+ * unsuccessful. Strategy mirrors the ingest suite: spy createWikiContext,
+ * mock ImportManager.
+ *
+ * Covers:
+ * - 403 when the caller lacks admin-system
+ * - 400 when sourceDir missing
+ * - failure result → response carries composed `error` ("file: message; …")
+ * - failure with >5 errors → summary capped at 5
+ * - success result → no `error` field
+ */
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import WikiRoutes from '../WikiRoutes';
+import { createMockWikiContext } from './__fixtures__/createMockWikiContext';
+
+const ADMIN = { username: 'admin', displayName: 'Admin', roles: ['admin'], isAuthenticated: true };
+
+function makeEngine(previewResult: unknown) {
+  const importManager = { previewImport: vi.fn().mockResolvedValue(previewResult) };
+  return {
+    getManager: vi.fn((name: string) => (name === 'ImportManager' ? importManager : null)),
+    _importManager: importManager
+  };
+}
+
+function installContextSpy(routes: WikiRoutes, permitted = true) {
+  const mockUserManager = { hasPermission: vi.fn().mockResolvedValue(permitted) };
+  vi.spyOn(routes, 'createWikiContext').mockImplementation((req: { userContext?: unknown }, options = {}) =>
+    createMockWikiContext(
+      { userContext: req.userContext as never, ...options },
+      { engine: (routes as unknown as { engine: unknown }).engine, mockUserManager }
+    ) as never
+  );
+  return mockUserManager;
+}
+
+function createRes() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json:   vi.fn().mockReturnThis()
+  };
+}
+
+function createReq(userContext: unknown, body: Record<string, unknown>) {
+  return { userContext, body, headers: {}, params: {}, query: {} } as never;
+}
+
+describe('WikiRoutes.adminImportPreview() — POST /admin/import/preview (#815)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  test('403 when caller lacks admin-system', async () => {
+    const routes = new WikiRoutes(makeEngine({}) as never);
+    installContextSpy(routes, false);
+    const res = createRes();
+    await routes.adminImportPreview(createReq(ADMIN, { sourceDir: '/x' }), res as never);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('400 when sourceDir missing', async () => {
+    const routes = new WikiRoutes(makeEngine({}) as never);
+    installContextSpy(routes);
+    const res = createRes();
+    await routes.adminImportPreview(createReq(ADMIN, {}), res as never);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  test('failure result surfaces composed top-level error', async () => {
+    const routes = new WikiRoutes(makeEngine({
+      success: false,
+      files: [],
+      converted: 0,
+      skipped: 0,
+      failed: 0,
+      errors: [{ file: '/Users/jim/Downloads/LD2450.md', message: 'Source path does not exist' }]
+    }) as never);
+    installContextSpy(routes);
+    const res = createRes();
+    await routes.adminImportPreview(createReq(ADMIN, { sourceDir: '/Users/jim/Downloads/LD2450.md' }), res as never);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.success).toBe(false);
+    expect(payload.error).toContain('/Users/jim/Downloads/LD2450.md: Source path does not exist');
+    expect(payload.errors).toHaveLength(1);
+  });
+
+  test('failure with many errors caps the summary at 5', async () => {
+    const errors = Array.from({ length: 8 }, (_, i) => ({ file: `/f${i}.md`, message: `boom ${i}` }));
+    const routes = new WikiRoutes(makeEngine({
+      success: false, files: [], converted: 0, skipped: 0, failed: 8, errors
+    }) as never);
+    installContextSpy(routes);
+    const res = createRes();
+    await routes.adminImportPreview(createReq(ADMIN, { sourceDir: '/dir' }), res as never);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.error.split(';')).toHaveLength(5);
+    expect(payload.error).toContain('/f0.md: boom 0');
+    expect(payload.error).not.toContain('boom 5');
+  });
+
+  test('success result carries no error field', async () => {
+    const routes = new WikiRoutes(makeEngine({
+      success: true,
+      files: [{ sourcePath: '/dir/a.md', written: false }],
+      converted: 1,
+      skipped: 0,
+      failed: 0,
+      errors: []
+    }) as never);
+    installContextSpy(routes);
+    const res = createRes();
+    await routes.adminImportPreview(createReq(ADMIN, { sourceDir: '/dir' }), res as never);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.success).toBe(true);
+    expect(payload).not.toHaveProperty('error');
+  });
+});

--- a/views/admin-import.ejs
+++ b/views/admin-import.ejs
@@ -390,7 +390,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 displayPreview(result);
                 executeBtn.disabled = false;
             } else {
-                alert('Preview failed: ' + (result.error || 'Unknown error'));
+                const detail = result.error
+                    || (Array.isArray(result.errors) && result.errors.length
+                        ? result.errors.map(e => e.file ? e.file + ': ' + e.message : e.message).join('\n')
+                        : 'Unknown error (HTTP ' + response.status + ')');
+                alert('Preview failed: ' + detail);
             }
         } catch (err) {
             alert('Preview failed: ' + err.message);


### PR DESCRIPTION
Fixes #815

**Root cause**: every failure path in `ImportManager.importPages` reports through an `errors[]` array (per-file messages), but the preview dialog only reads a top-level `error` string — so all preview failures alerted "Unknown error" and the computed cause was thrown away. The reporter's underlying error was almost certainly "Source path does not exist" (the path was workstation-local; paths resolve on the server).

**Changes**
- `adminImportPreview` composes a top-level `error` from `errors[]` (`file: message`, capped at 5) on unsuccessful results
- dialog falls back to joining `errors[]`, then to the HTTP status — "Unknown error" is no longer reachable with a structured response
- clearer message for the common case: "Source path does not exist **(paths are resolved on the server, not your browser's machine)**"

**Verified**
- 5 new handler tests; full suite 6238 passed, typecheck clean
- Live on jimstest: replayed the exact request from #815 — response now carries the real message; single-file happy-path preview unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)