### PR TITLE
fix: packaged-addon boot validator drifted from real npm discovery (#924)

### DIFF
--- a/docs/plugins/ReferringPagesPlugin.md
+++ b/docs/plugins/ReferringPagesPlugin.md
@@ -3,7 +3,7 @@ name: ReferringPagesPlugin
 description: Lists pages that link to the current page
 dateModified: '2025-12-18'
 category: plugins
-code: src/plugins/ReferringPagesPlugin.ts
+code: src/plugins/referringPagesPlugin.ts
 relatedModules:
   - PluginManager
   - LinkGraph

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngdpbase",
-  "version": "3.58.0",
+  "version": "3.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngdpbase",
-      "version": "3.58.0",
+      "version": "3.63.0",
       "license": "ISC",
       "dependencies": {
         "@elastic/elasticsearch": "^8.19.1",

--- a/src/managers/AddonsManager.ts
+++ b/src/managers/AddonsManager.ts
@@ -14,8 +14,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'node:crypto';
-import { minimatch } from 'minimatch';
 import matter from 'gray-matter';
+import {
+  splitAddonsPath,
+  findNodeModulesDir,
+  matchNpmPackageDirs
+} from '../utils/addonsPathResolver.js';
 import BaseManager from './BaseManager.js';
 import type { BackupData } from './BaseManager.js';
 import type { WikiEngine } from '../types/WikiEngine.js';
@@ -360,14 +364,11 @@ class AddonsManager extends BaseManager {
     // (#673 packaged model). An entry prefixed `node_modules:` is a glob of
     // npm packages to discover from node_modules (e.g. `node_modules:@jwilleke/*-addon`);
     // everything else is a directory path resolved to absolute (bundled/drop-in).
-    const NPM_PREFIX = 'node_modules:';
-    this.resolvedAddonsPaths = this.addonsPaths
-      .filter(p => !p.startsWith(NPM_PREFIX))
-      .map(p => path.resolve(p));
-    this.npmAddonPatterns = this.addonsPaths
-      .filter(p => p.startsWith(NPM_PREFIX))
-      .map(p => p.slice(NPM_PREFIX.length).trim())
-      .filter(Boolean);
+    // Shared with ConfigurationManager's boot-time addon-exists check (#924)
+    // so the two can no longer drift.
+    const { directories, npmPatterns } = splitAddonsPath(this.addonsPaths);
+    this.resolvedAddonsPaths = directories.map(p => path.resolve(p));
+    this.npmAddonPatterns = npmPatterns;
 
     // Discover and load add-ons
     await this.discoverAddons();
@@ -440,28 +441,12 @@ class AddonsManager extends BaseManager {
 
   /** Locate the node_modules directory (app root / cwd). */
   private findNodeModules(): string | null {
-    const nm = path.resolve(process.cwd(), 'node_modules');
-    return fs.existsSync(nm) && fs.statSync(nm).isDirectory() ? nm : null;
+    return findNodeModulesDir();
   }
 
   /** Expand a `@scope/glob` (or bare `glob`) pattern to package directories. */
   private resolveNpmAddonDirs(nmRoot: string, pattern: string): string[] {
-    let baseDir = nmRoot;
-    let nameGlob = pattern;
-    if (pattern.startsWith('@')) {
-      const slash = pattern.indexOf('/');
-      const scope = slash > 0 ? pattern.slice(0, slash) : pattern;
-      nameGlob = slash > 0 ? pattern.slice(slash + 1) : '*';
-      baseDir = path.join(nmRoot, scope);
-    }
-    if (!fs.existsSync(baseDir)) return [];
-    const out: string[] = [];
-    for (const entry of fs.readdirSync(baseDir, { withFileTypes: true })) {
-      if (entry.isDirectory() && !entry.name.startsWith('.') && minimatch(entry.name, nameGlob)) {
-        out.push(path.join(baseDir, entry.name));
-      }
-    }
-    return out;
+    return matchNpmPackageDirs(nmRoot, pattern);
   }
 
   /**

--- a/src/managers/ConfigurationManager.ts
+++ b/src/managers/ConfigurationManager.ts
@@ -4,6 +4,13 @@ import { WikiConfig } from '../types/Config.js';
 import logger from '../utils/logger.js';
 import BaseManager, { BackupData } from './BaseManager.js';
 import type { WikiEngine } from '../types/WikiEngine.js';
+import {
+  NPM_ADDON_PREFIX,
+  splitAddonsPath,
+  findNodeModulesDir,
+  matchNpmPackageDirs,
+  deriveAddonSlugFromPackageDirName
+} from '../utils/addonsPathResolver.js';
 
 interface ConfigManagerBackupData extends BackupData {
   customConfig: Partial<WikiConfig> | null;
@@ -216,12 +223,17 @@ class ConfigurationManager extends BaseManager {
 
   /**
    * #672: refuse to start if any `ngdpbase.addons.<id>.enabled = true` key
-   * references an `<id>` that has no matching addon directory in any
-   * configured `addons-path`. The discovery logic mirrors what
-   * `AddonsManager.scanAddonsDirectory()` does at runtime — directory name
-   * + `index.js` or `index.ts` present — but without importing the modules
-   * (boot-time speed; `ConfigurationManager.initialize()` runs before any
-   * managers).
+   * references an `<id>` that has no matching addon in any configured
+   * `addons-path` entry — either a directory (bundled/drop-in) or, per
+   * #673/#924, an npm package matched by a `node_modules:<glob>` entry.
+   * The discovery logic mirrors what `AddonsManager` does at runtime —
+   * directory/package name + `index.js` or `index.ts` present — but
+   * without importing the modules (boot-time speed;
+   * `ConfigurationManager.initialize()` runs before any managers). The
+   * directory-vs-npm-pattern split and npm glob matching are shared with
+   * `AddonsManager` via `utils/addonsPathResolver.ts` so the two can no
+   * longer drift out of sync (#924: they had, and packaged addons could
+   * never boot as a result).
    *
    * Catches the failure mode that caused the 2026-05-10 geohazardwatch.com
    * outage: the deploy configmap had `ngdpbase.addons.ve-geology.enabled =
@@ -229,12 +241,17 @@ class ConfigurationManager extends BaseManager {
    * `AddonsManager` silently treated the addon as disabled and registered
    * none of its plugins/managers.
    *
-   * False-positive consideration: an addon whose directory name differs
-   * from its module's `name:` field would be flagged here as "missing"
-   * even though it'd register at runtime. This is rare in practice (the
-   * directory name is the conventional identity); when it does happen,
-   * either rename the directory to match the module, or remove the
-   * `enabled` key (the addon will load by directory name anyway since the
+   * False-positive consideration: for directories, an addon whose
+   * directory name differs from its module's `name:` field would be
+   * flagged here as "missing" even though it'd register at runtime. For
+   * npm packages, the identity used here is derived from the package
+   * directory name alone (stripping a conventional trailing `-addon`
+   * suffix — see `deriveAddonSlugFromPackageDirName`), not from importing
+   * the module, so a package that doesn't follow that naming convention or
+   * whose module exports a different `name` has the same class of
+   * imprecision. Both are rare in practice (the name is the conventional
+   * identity); when it does happen, either rename to match, or remove the
+   * `enabled` key (the addon will still load by its real name since the
    * registration check is on the module's `name` field).
    */
   private assertConfiguredAddonsExist(): void {
@@ -248,15 +265,16 @@ class ConfigurationManager extends BaseManager {
     }
     if (enabledIds.length === 0) return;
 
-    // 2. Resolve addons-path (string or string[]; default './addons') —
-    // matching AddonsManager.initialize() lines 210-219.
+    // 2. Resolve addons-path (string or string[]; default './addons') into
+    // filesystem directories vs. `node_modules:<glob>` npm patterns —
+    // matching AddonsManager.initialize().
     const raw = this.getProperty('ngdpbase.managers.addons-manager.addons-path', './addons');
-    const paths = Array.isArray(raw) ? (raw as string[]) : [raw as string];
-    const resolvedPaths = paths.map(p => path.resolve(p));
+    const { directories, npmPatterns } = splitAddonsPath(raw);
+    const resolvedPaths = directories.map(p => path.resolve(p));
 
     // 3. Enumerate addon directories. Directory name + index.{js,ts} must
-    // be present, matching AddonsManager.scanAddonsDirectory() lines
-    // 263-287. No module loading at this stage.
+    // be present, matching AddonsManager.scanAddonsDirectory(). No module
+    // loading at this stage.
     const knownAddons = new Set<string>();
     for (const dirPath of resolvedPaths) {
       if (!fs.existsSync(dirPath)) continue;
@@ -275,7 +293,24 @@ class ConfigurationManager extends BaseManager {
       }
     }
 
-    // 4. Diff. Any enabled id without a matching directory is a misconfig.
+    // 3b. #673/#924: enumerate npm-packaged addons matching each
+    // `node_modules:<glob>` pattern, mirroring AddonsManager.scanNpmAddons().
+    // No module import here either (see false-positive note above).
+    if (npmPatterns.length > 0) {
+      const nmRoot = findNodeModulesDir();
+      if (nmRoot) {
+        for (const pattern of npmPatterns) {
+          for (const pkgDir of matchNpmPackageDirs(nmRoot, pattern)) {
+            const indexJs = path.join(pkgDir, 'index.js');
+            const indexTs = path.join(pkgDir, 'index.ts');
+            if (!fs.existsSync(indexJs) && !fs.existsSync(indexTs)) continue;
+            knownAddons.add(deriveAddonSlugFromPackageDirName(path.basename(pkgDir)));
+          }
+        }
+      }
+    }
+
+    // 4. Diff. Any enabled id without a matching directory/package is a misconfig.
     const unknown = enabledIds.filter(id => !knownAddons.has(id));
     if (unknown.length === 0) return;
 
@@ -286,10 +321,11 @@ class ConfigurationManager extends BaseManager {
       return guess ? `"${id}" (did you mean "${guess}"?)` : `"${id}"`;
     });
 
+    const searchedIn = [...resolvedPaths, ...npmPatterns.map(p => `${NPM_ADDON_PREFIX}${p}`)];
     throw new Error(
       '[ConfigurationManager] Refusing to start: ' +
       `'ngdpbase.addons.<id>.enabled = true' references unknown addon(s): ${suggestions.join(', ')}. ` +
-      `Available addons in [${resolvedPaths.map(p => `"${p}"`).join(', ')}]: ` +
+      `Available addons in [${searchedIn.map(p => `"${p}"`).join(', ')}]: ` +
       `${known.length ? known.join(', ') : '(none discovered)'}. ` +
       'Either rename the config key to match a discovered addon, or remove the enabled key. (#672)'
     );

--- a/src/managers/__tests__/ConfigurationManager.test.ts
+++ b/src/managers/__tests__/ConfigurationManager.test.ts
@@ -1165,6 +1165,126 @@ describe('ConfigurationManager', () => {
     });
   });
 
+  describe('configured-addons-exist guard — packaged (npm) addons (#673/#924)', () => {
+    /**
+     * #924: this guard used to resolve every addons-path entry — including
+     * `node_modules:<glob>` npm patterns — as a literal directory, so any
+     * enabled packaged addon was always "unknown" and crashed boot. These
+     * tests cover the fix: npm patterns are matched the same way
+     * `AddonsManager.scanNpmAddons()` does, via the shared
+     * `utils/addonsPathResolver.ts`.
+     */
+    const writeAddonDefault = async (extra: Record<string, unknown>) => {
+      await fs.writeJson(
+        path.join(tempDir, 'config', 'app-default-config.json'),
+        {
+          'ngdpbase.application-name': 'TestWiki',
+          'ngdpbase.application.base-url': 'http://localhost:3000',
+          'ngdpbase.application.contact.enabled': true,
+          'ngdpbase.application.contact.page': '',
+          'ngdpbase.application.contact.recipient': '',
+          ...extra
+        },
+        { spaces: 2 }
+      );
+    };
+
+    const seedAddonDir = async (root: string, name: string) => {
+      const dir = path.join(root, name);
+      await fs.ensureDir(dir);
+      await fs.writeFile(path.join(dir, 'index.js'), '// stub addon');
+    };
+
+    /**
+     * Seed a fake npm-installed addon package under `<tempDir>/node_modules/<rel>`
+     * (e.g. `rel = '@t/geohazardwatch-addon'`). `beforeEach` already
+     * `process.chdir(tempDir)`s, matching `findNodeModulesDir()`'s
+     * cwd-relative resolution.
+     */
+    const seedNpmAddon = async (rel: string, opts: { withIndex?: boolean } = {}) => {
+      const dir = path.join(tempDir, 'node_modules', rel);
+      await fs.ensureDir(dir);
+      if (opts.withIndex !== false) {
+        await fs.writeFile(path.join(dir, 'index.js'), '// stub addon', 'utf8');
+      }
+      await fs.writeJson(path.join(dir, 'package.json'), { name: rel, version: '1.0.0' });
+      return dir;
+    };
+
+    test('enabled key matches a discovered npm-packaged addon does not throw', async () => {
+      await seedNpmAddon('@t/geohazardwatch-addon');
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': ['node_modules:@t/*-addon'],
+        'ngdpbase.addons.geohazardwatch.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).resolves.not.toThrow();
+    });
+
+    test('enabled key with no matching npm package throws and lists the pattern searched', async () => {
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': ['node_modules:@t/*-addon'],
+        'ngdpbase.addons.geohazardwatch.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).rejects.toThrow(/Refusing to start.*geohazardwatch.*#672/s);
+      await expect(cm.initialize()).rejects.toThrow(/node_modules:@t\/\*-addon/);
+    });
+
+    test('mixed directory + npm addons-path: both kinds satisfy their own enabled keys', async () => {
+      const addonsRoot = path.join(tempDir, 'addons');
+      await seedAddonDir(addonsRoot, 'calendar');
+      await seedNpmAddon('@t/geohazardwatch-addon');
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': [addonsRoot, 'node_modules:@t/*-addon'],
+        'ngdpbase.addons.calendar.enabled': true,
+        'ngdpbase.addons.geohazardwatch.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).resolves.not.toThrow();
+    });
+
+    test('npm package without index.js/index.ts is not considered a known addon', async () => {
+      await seedNpmAddon('@t/geohazardwatch-addon', { withIndex: false });
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': ['node_modules:@t/*-addon'],
+        'ngdpbase.addons.geohazardwatch.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).rejects.toThrow(/geohazardwatch/);
+    });
+
+    test('a node_modules: pattern with no matches is harmless when nothing is enabled', async () => {
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': ['node_modules:@t/*-addon']
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).resolves.not.toThrow();
+    });
+
+    test('no node_modules directory at all is handled gracefully (not a crash)', async () => {
+      // No seedNpmAddon call at all — <tempDir>/node_modules never gets created.
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': ['node_modules:@t/*-addon'],
+        'ngdpbase.addons.geohazardwatch.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).rejects.toThrow(/Refusing to start.*geohazardwatch.*#672/s);
+    });
+
+    test('package folder not following the `-addon` naming convention is matched by its literal folder name', async () => {
+      // Naming-convention caveat documented on assertConfiguredAddonsExist:
+      // identity here is folder-name-derived, not the module's real `name`.
+      await seedNpmAddon('@t/oddball');
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': ['node_modules:@t/*'],
+        'ngdpbase.addons.oddball.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).resolves.not.toThrow();
+    });
+  });
+
   // ─────────────────────────────────────────────────────────────────────────
   // #775 — env-var-ref resolution in getProperty / getMaskedProperty
   // ─────────────────────────────────────────────────────────────────────────

--- a/src/utils/__tests__/addonsPathResolver.test.ts
+++ b/src/utils/__tests__/addonsPathResolver.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the shared addons-path parsing/npm-discovery helpers (#924).
+ */
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+import { describe, expect, test, afterEach, beforeEach } from 'vitest';
+import {
+  NPM_ADDON_PREFIX,
+  splitAddonsPath,
+  findNodeModulesDir,
+  matchNpmPackageDirs,
+  deriveAddonSlugFromPackageDirName
+} from '../addonsPathResolver';
+
+describe('splitAddonsPath', () => {
+  test('coerces a bare string into a single-entry directories list', () => {
+    expect(splitAddonsPath('./addons')).toEqual({ directories: ['./addons'], npmPatterns: [] });
+  });
+
+  test('splits mixed directory and node_modules: entries', () => {
+    const result = splitAddonsPath(['/app/addons', 'node_modules:@jwilleke/*-addon']);
+    expect(result.directories).toEqual(['/app/addons']);
+    expect(result.npmPatterns).toEqual(['@jwilleke/*-addon']);
+  });
+
+  test('trims whitespace around the pattern and drops empty patterns', () => {
+    const result = splitAddonsPath(['node_modules:  @t/*-addon  ', 'node_modules:', 'node_modules:   ']);
+    expect(result.npmPatterns).toEqual(['@t/*-addon']);
+  });
+
+  test('NPM_ADDON_PREFIX matches the documented syntax', () => {
+    expect(NPM_ADDON_PREFIX).toBe('node_modules:');
+  });
+});
+
+describe('findNodeModulesDir / matchNpmPackageDirs', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'addons-path-resolver-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir).catch(() => {});
+  });
+
+  test('findNodeModulesDir returns null when no node_modules exists', () => {
+    expect(findNodeModulesDir(tmpDir)).toBeNull();
+  });
+
+  test('findNodeModulesDir resolves an existing node_modules relative to cwd', async () => {
+    await fs.ensureDir(path.join(tmpDir, 'node_modules'));
+    expect(findNodeModulesDir(tmpDir)).toBe(path.join(tmpDir, 'node_modules'));
+  });
+
+  test('matchNpmPackageDirs expands a scoped glob against matching package directories', async () => {
+    const nm = path.join(tmpDir, 'node_modules');
+    await fs.ensureDir(path.join(nm, '@t', 'sample-addon'));
+    await fs.ensureDir(path.join(nm, '@t', 'other-addon'));
+    await fs.ensureDir(path.join(nm, '@t', 'not-matching'));
+
+    const dirs = matchNpmPackageDirs(nm, '@t/*-addon');
+    expect(dirs.sort()).toEqual(
+      [path.join(nm, '@t', 'other-addon'), path.join(nm, '@t', 'sample-addon')].sort()
+    );
+  });
+
+  test('matchNpmPackageDirs returns empty when the scope directory does not exist', () => {
+    expect(matchNpmPackageDirs(path.join(tmpDir, 'node_modules'), '@none/*-addon')).toEqual([]);
+  });
+
+  test('matchNpmPackageDirs skips dotfiles', async () => {
+    const nm = path.join(tmpDir, 'node_modules');
+    await fs.ensureDir(path.join(nm, '@t', '.hidden-addon'));
+    expect(matchNpmPackageDirs(nm, '@t/*-addon')).toEqual([]);
+  });
+
+  test('matchNpmPackageDirs supports a bare (unscoped) glob', async () => {
+    const nm = path.join(tmpDir, 'node_modules');
+    await fs.ensureDir(path.join(nm, 'sample-addon'));
+    expect(matchNpmPackageDirs(nm, '*-addon')).toEqual([path.join(nm, 'sample-addon')]);
+  });
+});
+
+describe('deriveAddonSlugFromPackageDirName', () => {
+  test('strips a trailing -addon suffix', () => {
+    expect(deriveAddonSlugFromPackageDirName('geohazardwatch-addon')).toBe('geohazardwatch');
+  });
+
+  test('returns the name as-is when there is no -addon suffix', () => {
+    expect(deriveAddonSlugFromPackageDirName('oddball')).toBe('oddball');
+  });
+
+  test('only strips a trailing suffix, not an embedded one', () => {
+    expect(deriveAddonSlugFromPackageDirName('addon-tools')).toBe('addon-tools');
+  });
+});

--- a/src/utils/addonsPathResolver.ts
+++ b/src/utils/addonsPathResolver.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared parsing/discovery for the `ngdpbase.managers.addons-manager.addons-path`
+ * config value.
+ *
+ * #924: `AddonsManager` (real runtime discovery) and `ConfigurationManager`
+ * (the #672 boot-time "does this enabled addon exist" safety check) used to
+ * each carry their own copy of this logic. They drifted: `AddonsManager` was
+ * updated for #673's `node_modules:<glob>` packaged-addon syntax, but the
+ * validator's copy was not, so it resolved a `node_modules:` entry as a
+ * literal (non-existent) directory and treated every packaged addon as
+ * "unknown" — crashing boot the moment one was enabled. Consolidating the
+ * parsing/matching into one module removes the class of bug, not just this
+ * instance of it.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { minimatch } from 'minimatch';
+
+/** Prefix marking an addons-path entry as an npm-package glob rather than a directory. */
+export const NPM_ADDON_PREFIX = 'node_modules:';
+
+export interface SplitAddonsPath {
+  /** Plain directory entries (bundled/drop-in), not yet resolved to absolute. */
+  directories: string[];
+  /** npm package name globs (the part after `node_modules:`), e.g. `@jwilleke/*-addon`. */
+  npmPatterns: string[];
+}
+
+/**
+ * Coerce the raw config value (string or string[]) and split it into
+ * filesystem directory entries vs. `node_modules:<glob>` npm patterns.
+ */
+export function splitAddonsPath(raw: unknown): SplitAddonsPath {
+  const entries = Array.isArray(raw) ? (raw as unknown[]).map(String) : [String(raw)];
+  return {
+    directories: entries.filter(p => !p.startsWith(NPM_ADDON_PREFIX)),
+    npmPatterns: entries
+      .filter(p => p.startsWith(NPM_ADDON_PREFIX))
+      .map(p => p.slice(NPM_ADDON_PREFIX.length).trim())
+      .filter(Boolean)
+  };
+}
+
+/** Locate the `node_modules` directory to search for packaged addons (resolved from cwd). */
+export function findNodeModulesDir(cwd: string = process.cwd()): string | null {
+  const nm = path.resolve(cwd, 'node_modules');
+  return fs.existsSync(nm) && fs.statSync(nm).isDirectory() ? nm : null;
+}
+
+/**
+ * Expand a `@scope/glob` (or bare `glob`) npm pattern to matching package
+ * directories under `nmRoot`.
+ */
+export function matchNpmPackageDirs(nmRoot: string, pattern: string): string[] {
+  let baseDir = nmRoot;
+  let nameGlob = pattern;
+  if (pattern.startsWith('@')) {
+    const slash = pattern.indexOf('/');
+    const scope = slash > 0 ? pattern.slice(0, slash) : pattern;
+    nameGlob = slash > 0 ? pattern.slice(slash + 1) : '*';
+    baseDir = path.join(nmRoot, scope);
+  }
+  if (!fs.existsSync(baseDir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(baseDir, { withFileTypes: true })) {
+    if (entry.isDirectory() && !entry.name.startsWith('.') && minimatch(entry.name, nameGlob)) {
+      out.push(path.join(baseDir, entry.name));
+    }
+  }
+  return out;
+}
+
+/**
+ * Best-effort addon identity for a packaged (npm) addon directory, derived
+ * from its package-directory name alone — no module import, matching the
+ * same boot-time-speed, no-module-loading design already accepted for the
+ * directory-scan case (see `ConfigurationManager.assertConfiguredAddonsExist`).
+ *
+ * Follows the documented packaged-addon naming convention
+ * (`@scope/<slug>-addon`, see docs/platform/deployment/addon-packaged.md):
+ * strips a trailing `-addon` suffix if present, else returns the folder name
+ * as-is.
+ *
+ * Caveat (same class as the existing directory-name heuristic): the addon's
+ * *real* identity is whatever its module exports as `name` at runtime. A
+ * package that doesn't follow the `-addon` naming convention, or whose
+ * module exports a different `name`, won't be matched precisely here — this
+ * is a validation-time approximation, not the source of truth.
+ */
+export function deriveAddonSlugFromPackageDirName(dirName: string): string {
+  const suffix = '-addon';
+  return dirName.endsWith(suffix) ? dirName.slice(0, -suffix.length) : dirName;
+}


### PR DESCRIPTION
## Summary

Fixes #924: `ConfigurationManager.assertConfiguredAddonsExist()` (the #672 boot-time safety check — refuse to start if an `ngdpbase.addons.<id>.enabled = true` key has no matching addon) was never updated for #673's `node_modules:<glob>` packaged-addon syntax. It resolved every `addons-path` entry as a literal directory, so a `node_modules:@scope/*-addon` entry always mis-resolved to a non-existent path — meaning **any packaged (npm-installed) addon that needed to be enabled crashed the app on boot**, even though `AddonsManager`'s real runtime discovery found it correctly.

## Root cause

Two independently hand-written copies of "split `addons-path` into directories vs. npm-glob patterns, then match the glob" had drifted apart:

- `AddonsManager.initialize()` / `scanNpmAddons()` — correct, updated for #673.
- `ConfigurationManager.assertConfiguredAddonsExist()` — its own docstring claimed to "mirror" the `AddonsManager` logic, but was never actually updated when #673 shipped.

## Fix

- New shared module `src/utils/addonsPathResolver.ts` — consolidates the `node_modules:` prefix split, `node_modules` directory resolution, and `@scope/glob` matching into one place both managers use. This is the actual fix for the *class* of bug (two hand-maintained mirrors drifting), not just this one instance.
- `AddonsManager.ts` refactored to delegate to the shared module — behavior-preserving; its 70 existing tests pass unchanged.
- `ConfigurationManager.assertConfiguredAddonsExist()` now also matches `node_modules:<glob>` entries, deriving each candidate's identity from its package directory name (stripping the conventional trailing `-addon` suffix — see `addon-packaged.md`), **without importing the module** — consistent with the exact same no-module-loading, boot-time-speed design this function already uses (and already accepts the same class of false-positive risk for) the directory-scan case. Documented that caveat explicitly for the npm case too.
- The "Available addons in [...]" error message now also lists the raw npm patterns searched, not just resolved directory paths, so an operator debugging a typo isn't confused by their `node_modules:` entry silently disappearing from the message.

## Testing

- 20 new tests: 7 in `ConfigurationManager.test.ts` (packaged-addon enabled/missing/mixed/no-node_modules/naming-convention cases), 13 for the new `addonsPathResolver` module.
- Full suite: **6603 passed, 9 skipped (pre-existing), 0 failures.** `tsc --noEmit` and `npm run lint:code` clean.
- Also fixed an unrelated pre-existing docs-coverage break hit while committing: `docs/plugins/ReferringPagesPlugin.md`'s `code:` frontmatter had the wrong filename casing (`ReferringPagesPlugin.ts` vs. the actual `referringPagesPlugin.ts`), which failed the pre-commit hook regardless of this change.

**Beyond unit tests**, verified against a real built image (not just mocks):

1. Built `ghcr.io/jwilleke/ngdpbase` from this branch, installed a locally-packed (not published) `@jwilleke/geohazardwatch-addon` tarball into it — the exact scenario that crashed before this fix. Confirmed: no crash, addon discovered `[enabled]`, all 9 plugins registered, 14 pages seeded, and the addon's own API/pages serve real responses (200s, valid JSON).
2. Verified the full **deploy → operator-edit → redeploy** lifecycle on a persistent volume, matching how this ships in production:
   - Deployed addon v1 → page `Landslides` seeded untouched.
   - Manually edited the live `Attribution` page (simulating an operator edit).
   - Deployed addon v2 with new content for **both** `Landslides` (untouched) and `Attribution` (edited).
   - Result: `Landslides` auto-reseeded with the new content (`source changed, page unmodified`); `Attribution`'s edit was preserved and the update correctly skipped (`page was locally modified — skipped`).

## Related

- #672 — the validator this bug lives in.
- #673 — the packaged-model feature this validator didn't know about.
- jwilleke/geohazardwatch#152 / jwilleke/geohazardwatch#154 — the packaged-addon migration that surfaced this; blocked on this fix landing + a base-image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)