### PR TITLE
feat(addons): canonical slug identity across discovery, isEnabled, validator (#927)

### DIFF
--- a/addons/calendar/package.json
+++ b/addons/calendar/package.json
@@ -20,6 +20,7 @@
     "node": ">=24"
   },
   "ngdpbase": {
+    "slug": "calendar",
     "type": "additive",
     "dependencies": [
       "forms"

--- a/addons/elasticsearch/package.json
+++ b/addons/elasticsearch/package.json
@@ -15,6 +15,7 @@
     "node": ">=24"
   },
   "ngdpbase": {
+    "slug": "elasticsearch",
     "type": "additive"
   }
 }

--- a/addons/feeds/package.json
+++ b/addons/feeds/package.json
@@ -12,6 +12,7 @@
     "node": ">=24"
   },
   "ngdpbase": {
+    "slug": "feeds",
     "type": "additive"
   },
   "dependencies": {

--- a/addons/forms/package.json
+++ b/addons/forms/package.json
@@ -19,6 +19,7 @@
     "node": ">=24"
   },
   "ngdpbase": {
+    "slug": "forms",
     "type": "additive"
   }
 }

--- a/addons/journal/package.json
+++ b/addons/journal/package.json
@@ -19,6 +19,7 @@
     "node": ">=24"
   },
   "ngdpbase": {
+    "slug": "journal",
     "type": "additive"
   }
 }

--- a/docs/platform/deployment/addon-packaged.md
+++ b/docs/platform/deployment/addon-packaged.md
@@ -40,6 +40,8 @@ A domain addon today typically owns its whole image (`FROM ngdpbase + WORKDIR + 
 
 Net: the bespoke per-addon image collapses to a generic base image + one `npm install` line + config. The two version axes (ngdpbase base, addon package) decouple, which is what removes the drift.
 
+> **Audit every deployment artifact that references the addon's drop-in path directly — not just the main Dockerfile.** CronJobs, init containers, sidecars, and debug/exec scripts that hardcode the old drop-in layout (e.g. `workingDir: /opt/<slug>`, `node addons/<slug>/import/*.js`) break **silently on their next scheduled run** rather than at deploy time, because the packaged model changes where the addon's files physically live (`node_modules/<scope>/<slug>-addon/`, not `addons/<slug>/` or `/opt/<slug>/`). Image-automation (e.g. Flux) will happily bump such a job's pinned tag to the new packaged image with nothing positioned to catch the broken path. Grep your whole deployment — every manifest, not just the app Deployment — for the old path before cutting over. (Surfaced in geohazardwatch#152: a daily data-import CronJob was a second, independent consumer of `/opt/geohazardwatch` and was not on the migration checklist.)
+
 ## How discovery works
 
 Add a `node_modules:<glob>` entry to `addons-path`:
@@ -76,18 +78,20 @@ A packaged addon is an ordinary npm package whose installed directory satisfies 
 
 - Package name convention: `@<scope>/<slug>-addon` (so the `*-addon` glob catches it).
 - `main` must resolve to an `index.js` (or the discovery falls back to `index.js`/`index.ts` in the package root).
-- The optional `ngdpbase` block is read into the addon's `manifest` (same as a drop-in's `package.json` `ngdpbase` block).
+- `ngdpbase.slug` is the addon's **canonical identity** (#927): it is the registry key, the `ngdpbase.addons.<slug>.enabled` config-gate key, the dependency-reference name, and what the boot-time validator matches — all resolved from `package.json` *without importing the module*. **Declare it.** If omitted, identity falls back to the package directory name minus a trailing `-addon` (so `@jwilleke/geohazardwatch-addon` → `geohazardwatch`), but relying on that couples your identity to the package folder name — declaring `slug` is authoritative and explicit.
 
 **`index.js`** — the module contract, unchanged across all three models:
 
 ```js
 module.exports = {
-  name: 'geohazardwatch',           // the addon slug — the config-gate key
+  name: 'geohazardwatch',           // display label; MUST equal ngdpbase.slug
   version: '1.4.2',
   register(engine, config) { /* … */ },
-  dependencies: []                  // optional addon deps
+  dependencies: []                  // optional addon deps (referenced by slug)
 };
 ```
+
+The module's exported `name` is a display label, not the identity — at load time `AddonsManager` warns (errors for `type: 'domain'`) if `name !== slug`. Keep them equal.
 
 The addon is still gated by `ngdpbase.addons.<name>.enabled` — installing the package makes it *discoverable*, not automatically active.
 

--- a/src/managers/AddonsManager.ts
+++ b/src/managers/AddonsManager.ts
@@ -18,7 +18,8 @@ import matter from 'gray-matter';
 import {
   splitAddonsPath,
   findNodeModulesDir,
-  matchNpmPackageDirs
+  matchNpmPackageDirs,
+  resolveAddonSlug
 } from '../utils/addonsPathResolver.js';
 import BaseManager from './BaseManager.js';
 import type { BackupData } from './BaseManager.js';
@@ -205,6 +206,15 @@ export interface AddonProfileSectionEntry extends AddonProfileSection {
  * All fields are optional — omitting the key entirely is valid.
  */
 export interface AddonManifest {
+  /**
+   * Canonical addon identity (#927). Authoritative id used as the registry
+   * key, the `ngdpbase.addons.<slug>.enabled` config key, dependency
+   * references, and the boot-time validator's match — read statically from
+   * `package.json` with no module import. When absent, identity falls back
+   * to the package/folder name (minus a conventional trailing `-addon`).
+   * The module's exported `name` is a display label and must equal this.
+   */
+  slug?: string;
   /** 'domain' = this addon IS the site identity; 'additive' = augments an existing wiki */
   type?: 'domain' | 'additive';
   /**
@@ -418,7 +428,7 @@ class AddonsManager extends BaseManager {
     for (const entry of entries) {
       if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
       if (entry.name === 'shared') continue; // reserved for shared utilities
-      await this.registerAddonFromDir(path.join(dirPath, entry.name), dirPath);
+      await this.registerAddonFromDir(path.join(dirPath, entry.name), dirPath, 'directory');
     }
   }
 
@@ -435,7 +445,7 @@ class AddonsManager extends BaseManager {
       return;
     }
     for (const pkgDir of this.resolveNpmAddonDirs(nmRoot, pattern)) {
-      await this.registerAddonFromDir(pkgDir, `npm:${pattern}`);
+      await this.registerAddonFromDir(pkgDir, `npm:${pattern}`, 'npm');
     }
   }
 
@@ -452,10 +462,17 @@ class AddonsManager extends BaseManager {
   /**
    * Load a single addon from its directory (index.js/ts + optional package.json
    * `ngdpbase` manifest) and register it. Shared by directory scans and npm
-   * (#673) discovery; `sourceLabel` is for logging only. Duplicate names are
-   * skipped — since npm discovery runs last, a bundled/drop-in addon wins.
+   * (#673) discovery; `sourceLabel` is for logging only. `source` selects the
+   * no-slug identity fallback (#927): a directory addon's folder name is its
+   * identity verbatim, while an npm package strips the conventional `-addon`
+   * suffix. Duplicate ids are skipped — since npm discovery runs last, a
+   * bundled/drop-in addon wins.
    */
-  private async registerAddonFromDir(addonPath: string, sourceLabel: string): Promise<void> {
+  private async registerAddonFromDir(
+    addonPath: string,
+    sourceLabel: string,
+    source: 'directory' | 'npm'
+  ): Promise<void> {
     const folderName = path.basename(addonPath);
     const indexPath = path.join(addonPath, 'index.js');
     const indexTsPath = path.join(addonPath, 'index.ts');
@@ -478,12 +495,6 @@ class AddonsManager extends BaseManager {
         logger.error(`Add-on ${addonModule.name} missing required register() function, skipping`);
         return;
       }
-      if (this.addons.has(addonModule.name)) {
-        logger.warn(`[AddonsManager] Duplicate add-on name '${addonModule.name}' from ${sourceLabel} — skipping (already loaded)`);
-        return;
-      }
-
-      const enabled = this.isEnabled(addonModule.name);
 
       let manifest: AddonManifest | null = null;
       const pkgPath = path.join(addonPath, 'package.json');
@@ -496,7 +507,32 @@ class AddonsManager extends BaseManager {
         }
       }
 
-      this.addons.set(addonModule.name, {
+      // #927: canonical identity is the statically-declared slug (resolved the
+      // SAME import-free way the boot validator uses), NOT the imported
+      // module.name. The registry key, isEnabled config lookup, dedup and
+      // dependency references all key off this. module.name is a display
+      // label validated against it below.
+      const canonicalId = resolveAddonSlug(addonPath, source);
+      if (addonModule.name !== canonicalId) {
+        const msg =
+          `[AddonsManager] Add-on identity mismatch in ${folderName}: module name ` +
+          `'${addonModule.name}' != canonical slug '${canonicalId}' (from package.json ` +
+          `ngdpbase.slug or folder name). Using '${canonicalId}' as identity; config key is ` +
+          `ngdpbase.addons.${canonicalId}.enabled. Align the module's name with the slug.`;
+        // A domain addon's identity IS the site identity — a mismatch there is
+        // far more dangerous, so surface it at error level.
+        if (manifest?.type === 'domain') logger.error(msg);
+        else logger.warn(msg);
+      }
+
+      if (this.addons.has(canonicalId)) {
+        logger.warn(`[AddonsManager] Duplicate add-on '${canonicalId}' from ${sourceLabel} — skipping (already loaded)`);
+        return;
+      }
+
+      const enabled = this.isEnabled(canonicalId);
+
+      this.addons.set(canonicalId, {
         path: addonPath,
         module: addonModule,
         enabled,
@@ -505,8 +541,9 @@ class AddonsManager extends BaseManager {
         manifest
       });
 
+      const label = addonModule.name === canonicalId ? canonicalId : `${canonicalId} (name: ${addonModule.name})`;
       logger.info(
-        `📦 Discovered add-on: ${addonModule.name} v${addonModule.version || 'unknown'} ` +
+        `📦 Discovered add-on: ${label} v${addonModule.version || 'unknown'} ` +
           `[${enabled ? 'enabled' : 'disabled'}] (${sourceLabel})`
       );
     } catch (err) {

--- a/src/managers/ConfigurationManager.ts
+++ b/src/managers/ConfigurationManager.ts
@@ -9,7 +9,7 @@ import {
   splitAddonsPath,
   findNodeModulesDir,
   matchNpmPackageDirs,
-  deriveAddonSlugFromPackageDirName
+  resolveAddonSlug
 } from '../utils/addonsPathResolver.js';
 
 interface ConfigManagerBackupData extends BackupData {
@@ -227,10 +227,10 @@ class ConfigurationManager extends BaseManager {
    * `addons-path` entry — either a directory (bundled/drop-in) or, per
    * #673/#924, an npm package matched by a `node_modules:<glob>` entry.
    * The discovery logic mirrors what `AddonsManager` does at runtime —
-   * directory/package name + `index.js` or `index.ts` present — but
-   * without importing the modules (boot-time speed;
-   * `ConfigurationManager.initialize()` runs before any managers). The
-   * directory-vs-npm-pattern split and npm glob matching are shared with
+   * directory/package present with `index.js` or `index.ts` — but without
+   * importing the modules (boot-time speed; `ConfigurationManager.initialize()`
+   * runs before any managers). The directory-vs-npm-pattern split, npm glob
+   * matching, AND the canonical-identity resolution are all shared with
    * `AddonsManager` via `utils/addonsPathResolver.ts` so the two can no
    * longer drift out of sync (#924: they had, and packaged addons could
    * never boot as a result).
@@ -241,18 +241,16 @@ class ConfigurationManager extends BaseManager {
    * `AddonsManager` silently treated the addon as disabled and registered
    * none of its plugins/managers.
    *
-   * False-positive consideration: for directories, an addon whose
-   * directory name differs from its module's `name:` field would be
-   * flagged here as "missing" even though it'd register at runtime. For
-   * npm packages, the identity used here is derived from the package
-   * directory name alone (stripping a conventional trailing `-addon`
-   * suffix — see `deriveAddonSlugFromPackageDirName`), not from importing
-   * the module, so a package that doesn't follow that naming convention or
-   * whose module exports a different `name` has the same class of
-   * imprecision. Both are rare in practice (the name is the conventional
-   * identity); when it does happen, either rename to match, or remove the
-   * `enabled` key (the addon will still load by its real name since the
-   * registration check is on the module's `name` field).
+   * #927: identity here is the canonical slug — `package.json`
+   * `ngdpbase.slug`, else the folder name minus a conventional trailing
+   * `-addon` (`resolvePackagedAddonSlug`). This is the EXACT same import-free
+   * resolution `AddonsManager.registerAddonFromDir()` uses as its registry
+   * key and `isEnabled` lookup, so this check is now precise rather than a
+   * guess: an enabled `<id>` is known iff the runtime would register under
+   * that same `<id>`. The only residual imprecision is a module whose
+   * exported `name` disagrees with its slug — but since #927 makes the slug
+   * (not `name`) the runtime identity too, that disagreement no longer
+   * affects either layer's `<id>`; it only earns a load-time warning.
    */
   private assertConfiguredAddonsExist(): void {
     if (!this.mergedConfig) return;
@@ -285,10 +283,14 @@ class ConfigurationManager extends BaseManager {
       try { entries = fs.readdirSync(dirPath, { withFileTypes: true }); } catch { continue; }
       for (const entry of entries) {
         if (!entry.isDirectory() || entry.name.startsWith('.') || entry.name === 'shared') continue;
-        const indexJs = path.join(dirPath, entry.name, 'index.js');
-        const indexTs = path.join(dirPath, entry.name, 'index.ts');
+        const addonDir = path.join(dirPath, entry.name);
+        const indexJs = path.join(addonDir, 'index.js');
+        const indexTs = path.join(addonDir, 'index.ts');
         if (fs.existsSync(indexJs) || fs.existsSync(indexTs)) {
-          knownAddons.add(entry.name);
+          // #927: resolve identity the same import-free way AddonsManager
+          // registers it — package.json ngdpbase.slug, else the folder name
+          // verbatim (directory addons are not stripped).
+          knownAddons.add(resolveAddonSlug(addonDir, 'directory'));
         }
       }
     }
@@ -304,7 +306,11 @@ class ConfigurationManager extends BaseManager {
             const indexJs = path.join(pkgDir, 'index.js');
             const indexTs = path.join(pkgDir, 'index.ts');
             if (!fs.existsSync(indexJs) && !fs.existsSync(indexTs)) continue;
-            knownAddons.add(deriveAddonSlugFromPackageDirName(path.basename(pkgDir)));
+            // #927: identity is the statically-declared slug, resolved the
+            // exact same import-free way AddonsManager registers it — so this
+            // is now an exact match, not the folder-name-derived guess #925
+            // had to fall back to.
+            knownAddons.add(resolveAddonSlug(pkgDir, 'npm'));
           }
         }
       }

--- a/src/managers/__tests__/AddonsManager.test.ts
+++ b/src/managers/__tests__/AddonsManager.test.ts
@@ -187,6 +187,47 @@ describe('AddonsManager', () => {
       expect(manager.getAddonNames()).toContain('test-addon');
     });
 
+    test('#927: registry is keyed on the declared slug, not the module name', async () => {
+      // Folder + module name 'gadget', but the addon declares slug 'widget'.
+      const addonDir = path.join(tmpDir, 'gadget');
+      await fs.mkdir(addonDir);
+      await fs.writeFile(
+        path.join(addonDir, 'index.js'),
+        "module.exports = { name: 'gadget', version: '1.0.0', register: async () => {} };",
+        'utf8'
+      );
+      await fs.writeFile(
+        path.join(addonDir, 'package.json'),
+        JSON.stringify({ name: 'gadget', ngdpbase: { slug: 'widget' } }),
+        'utf8'
+      );
+
+      const manager = new AddonsManager(makeEngine(makeConfigManager()));
+      await manager.initialize();
+
+      // Identity is the slug; the module name is not an identity.
+      expect(manager.hasAddon('widget')).toBe(true);
+      expect(manager.hasAddon('gadget')).toBe(false);
+      expect(manager.getAddonNames()).toContain('widget');
+    });
+
+    test('#927: a directory addon named `<x>-addon` keeps that verbatim identity', async () => {
+      const addonDir = path.join(tmpDir, 'shiny-addon');
+      await fs.mkdir(addonDir);
+      await fs.writeFile(
+        path.join(addonDir, 'index.js'),
+        "module.exports = { name: 'shiny-addon', version: '1.0.0', register: async () => {} };",
+        'utf8'
+      );
+
+      const manager = new AddonsManager(makeEngine(makeConfigManager()));
+      await manager.initialize();
+
+      // No slug declared, directory source → verbatim, NOT stripped to 'shiny'.
+      expect(manager.hasAddon('shiny-addon')).toBe(true);
+      expect(manager.hasAddon('shiny')).toBe(false);
+    });
+
     test('skips hidden directories', async () => {
       const hiddenDir = path.join(tmpDir, '.hidden-addon');
       await fs.mkdir(hiddenDir);

--- a/src/managers/__tests__/ConfigurationManager.test.ts
+++ b/src/managers/__tests__/ConfigurationManager.test.ts
@@ -1285,6 +1285,72 @@ describe('ConfigurationManager', () => {
     });
   });
 
+  describe('configured-addons-exist guard — canonical slug identity (#927)', () => {
+    /**
+     * #927: the validator now resolves an addon's identity from the declared
+     * `package.json` `ngdpbase.slug` — the SAME import-free rule AddonsManager
+     * registers under — instead of the folder name. These prove the enabled
+     * `<id>` must match the slug, not the folder.
+     */
+    const writeAddonDefault = async (extra: Record<string, unknown>) => {
+      await fs.writeJson(
+        path.join(tempDir, 'config', 'app-default-config.json'),
+        {
+          'ngdpbase.application-name': 'TestWiki',
+          'ngdpbase.application.base-url': 'http://localhost:3000',
+          'ngdpbase.application.contact.enabled': true,
+          'ngdpbase.application.contact.page': '',
+          'ngdpbase.application.contact.recipient': '',
+          ...extra
+        },
+        { spaces: 2 }
+      );
+    };
+
+    const seedDirAddonWithSlug = async (root: string, folder: string, slug: string) => {
+      const dir = path.join(root, folder);
+      await fs.ensureDir(dir);
+      await fs.writeFile(path.join(dir, 'index.js'), '// stub addon');
+      await fs.writeJson(path.join(dir, 'package.json'), { name: folder, ngdpbase: { slug } });
+    };
+
+    test('enabling the declared slug (not the folder name) satisfies the guard', async () => {
+      const addonsRoot = path.join(tempDir, 'addons');
+      // folder 'geohazardwatch' but the addon declares slug 've-geology'
+      await seedDirAddonWithSlug(addonsRoot, 'geohazardwatch', 've-geology');
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': [addonsRoot],
+        'ngdpbase.addons.ve-geology.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).resolves.not.toThrow();
+    });
+
+    test('enabling the folder name when a different slug is declared throws', async () => {
+      const addonsRoot = path.join(tempDir, 'addons');
+      await seedDirAddonWithSlug(addonsRoot, 'geohazardwatch', 've-geology');
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': [addonsRoot],
+        'ngdpbase.addons.geohazardwatch.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).rejects.toThrow(/Refusing to start.*geohazardwatch.*#672/s);
+    });
+
+    test('a directory addon named `<x>-addon` keeps that verbatim identity (no -addon strip)', async () => {
+      const addonsRoot = path.join(tempDir, 'addons');
+      const dir = path.join(addonsRoot, 'test-addon');
+      await fs.ensureDir(dir);
+      await fs.writeFile(path.join(dir, 'index.js'), '// stub addon'); // no package.json → verbatim folder
+      await writeAddonDefault({
+        'ngdpbase.managers.addons-manager.addons-path': [addonsRoot],
+        'ngdpbase.addons.test-addon.enabled': true
+      });
+      const cm = new ConfigurationManager(mockEngine);
+      await expect(cm.initialize()).resolves.not.toThrow();
+    });
+  });
+
   // ─────────────────────────────────────────────────────────────────────────
   // #775 — env-var-ref resolution in getProperty / getMaskedProperty
   // ─────────────────────────────────────────────────────────────────────────

--- a/src/utils/__tests__/addonsPathResolver.test.ts
+++ b/src/utils/__tests__/addonsPathResolver.test.ts
@@ -10,7 +10,8 @@ import {
   splitAddonsPath,
   findNodeModulesDir,
   matchNpmPackageDirs,
-  deriveAddonSlugFromPackageDirName
+  deriveAddonSlugFromPackageDirName,
+  resolveAddonSlug
 } from '../addonsPathResolver';
 
 describe('splitAddonsPath', () => {
@@ -94,5 +95,60 @@ describe('deriveAddonSlugFromPackageDirName', () => {
 
   test('only strips a trailing suffix, not an embedded one', () => {
     expect(deriveAddonSlugFromPackageDirName('addon-tools')).toBe('addon-tools');
+  });
+});
+
+describe('resolveAddonSlug (#927 canonical identity)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'resolve-addon-slug-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir).catch(() => {});
+  });
+
+  const seed = async (dirName: string, ngdpbase?: Record<string, unknown>) => {
+    const dir = path.join(tmpDir, dirName);
+    await fs.ensureDir(dir);
+    if (ngdpbase !== undefined) {
+      await fs.writeJson(path.join(dir, 'package.json'), { name: dirName, ngdpbase });
+    }
+    return dir;
+  };
+
+  test('declared ngdpbase.slug wins over the folder name (directory)', async () => {
+    const dir = await seed('geohazardwatch-addon', { slug: 'geohazardwatch' });
+    expect(resolveAddonSlug(dir, 'directory')).toBe('geohazardwatch');
+  });
+
+  test('declared ngdpbase.slug wins over the folder name (npm)', async () => {
+    const dir = await seed('weird-pkg-name', { slug: 'geohazardwatch' });
+    expect(resolveAddonSlug(dir, 'npm')).toBe('geohazardwatch');
+  });
+
+  test('directory fallback is the folder name VERBATIM (never strips -addon)', async () => {
+    const dir = await seed('test-addon'); // no package.json
+    expect(resolveAddonSlug(dir, 'directory')).toBe('test-addon');
+  });
+
+  test('npm fallback strips the conventional trailing -addon', async () => {
+    const dir = await seed('geohazardwatch-addon'); // no package.json
+    expect(resolveAddonSlug(dir, 'npm')).toBe('geohazardwatch');
+  });
+
+  test('blank/whitespace slug is ignored, falls back per source', async () => {
+    const dir = await seed('sample-addon', { slug: '   ' });
+    expect(resolveAddonSlug(dir, 'directory')).toBe('sample-addon');
+    expect(resolveAddonSlug(dir, 'npm')).toBe('sample');
+  });
+
+  test('invalid/unreadable package.json falls back per source', async () => {
+    const dir = path.join(tmpDir, 'broken-addon');
+    await fs.ensureDir(dir);
+    await fs.writeFile(path.join(dir, 'package.json'), '{ not json', 'utf8');
+    expect(resolveAddonSlug(dir, 'directory')).toBe('broken-addon');
+    expect(resolveAddonSlug(dir, 'npm')).toBe('broken');
   });
 });

--- a/src/utils/addonsPathResolver.ts
+++ b/src/utils/addonsPathResolver.ts
@@ -92,3 +92,39 @@ export function deriveAddonSlugFromPackageDirName(dirName: string): string {
   const suffix = '-addon';
   return dirName.endsWith(suffix) ? dirName.slice(0, -suffix.length) : dirName;
 }
+
+/**
+ * Canonical identity for an addon directory (#927), resolved the SAME
+ * import-free way in every layer (discovery, `isEnabled`, the boot-time
+ * validator) so the four historical identities (folder name, module `name`,
+ * config key, manifest slug) can no longer drift:
+ *
+ *   canonicalId = package.json `ngdpbase.slug`  ??  deriveAddonSlugFromPackageDirName(folder)
+ *
+ * Reads `package.json` statically — never imports the module — which is what
+ * lets the boot validator compute the exact id the runtime will register
+ * under, instead of guessing. The module's exported `name` is a display
+ * label validated against this at load time, not a source of identity.
+ */
+export function resolveAddonSlug(
+  addonDir: string,
+  source: 'directory' | 'npm'
+): string {
+  const dirName = path.basename(addonDir);
+  const pkgPath = path.join(addonDir, 'package.json');
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+      ngdpbase?: { slug?: unknown };
+    };
+    const slug = pkg?.ngdpbase?.slug;
+    if (typeof slug === 'string' && slug.trim()) return slug.trim();
+  } catch {
+    /* no/invalid package.json — fall back to the folder-derived id */
+  }
+  // Fallback when no slug is declared. npm packages follow the
+  // `@scope/<slug>-addon` publishing convention, so strip the conventional
+  // trailing `-addon`. A plain directory (bundled/drop-in) addon's folder
+  // name IS its identity verbatim — an addon may legitimately be named
+  // `something-addon` on disk — so never strip there.
+  return source === 'npm' ? deriveAddonSlugFromPackageDirName(dirName) : dirName;
+}


### PR DESCRIPTION
## Summary

Fixes #927. An addon had **four** identities that could silently disagree — package/folder name, module `name` (what the runtime enabled on), the `ngdpbase.addons.<id>.enabled` config key, and a documented-but-inert `manifest.slug`. Because identity was only knowable by *importing* the module, the boot-time validator and pre-import discovery each guessed a different proxy and drifted. That drift is the shared root of #672, #924/#925, and the slug half of #926 — each patched a symptom.

## Fix

`package.json` `ngdpbase.slug` becomes the single authoritative identity, resolved the **same import-free way** in every layer via one shared `resolveAddonSlug()`:

```
canonicalId = ngdpbase.slug ?? (source === 'npm' ? folder minus trailing '-addon' : folder verbatim)
```

Because `slug` lives in `package.json`, the validator computes the exact id the runtime registers under — the guessing (and the drift) is structurally gone.

- **`AddonsManager`** keys the registry, `isEnabled`, dedup and dependency refs on `canonicalId`. `module.name` is demoted to a display label; a `name !== slug` mismatch warns (errors for `type:'domain'`). A `source` arg selects the no-slug fallback: **directory** addons keep their folder name verbatim (an addon may legitimately be named `x-addon`); **npm** packages strip the conventional `-addon`.
- **`ConfigurationManager`** boot validator resolves identity the identical way for both directory and npm scans — exact match, no folder-name guess (removes #925's weak fallback for the validator path).
- **`addonsPathResolver.resolveAddonSlug`** is the one shared resolver — the two managers can no longer drift.

## Backward compatibility

All 5 bundled addons declare an explicit `slug` equal to their current `name`; `slug == name == folder` for every existing addon and every deployment config key → **zero config break**. Addons with no slug fall back to the source-aware folder derivation. Full suite green.

## Docs (closes #926)

- `slug` documented as authoritative; module `name` must equal it (gap 1).
- Migration audit line: every drop-in-path consumer — CronJobs, init containers, sidecars, exec scripts — not just the main Dockerfile, breaks **silently on the next scheduled run** after cutover (gap 2, real geohazardwatch#152 near-miss).

## Testing

+11 tests: resolver slug-precedence + source-aware fallback; validator slug authority for directory addons; runtime registry keyed on slug; `x-addon` directory keeps verbatim identity. **Full suite 6617 pass, 9 skipped, 0 fail.** `tsc --noEmit` + `lint:code` clean. Server restart on jimstest boots clean (302), all bundled addons discovered under slug identity, no mismatch warnings.

## Related

- Supersedes the slug half of #926 (CronJob-audit docs half folded in here); #926 can close when this lands.
- Root-causes #672, #924/#925.
- Unblocks geohazardwatch#152/#154 with an explicit declared identity instead of a folder-name guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
