### PR TITLE
feat(addons): unify addon-page modified-detection on one shared evaluator (#931)

### DIFF
--- a/src/managers/AddonsManager.ts
+++ b/src/managers/AddonsManager.ts
@@ -13,7 +13,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { createHash } from 'node:crypto';
+import { pageSourceHash, evaluateSeededAddonPage } from '../utils/addonPageSync.js';
 import matter from 'gray-matter';
 import {
   splitAddonsPath,
@@ -715,22 +715,24 @@ class AddonsManager extends BaseManager {
         if (existing) {
           const existingMeta = (existing.metadata as Record<string, unknown> | undefined) ?? {};
           const existingSlug = (existingMeta.slug as string) || slug;
-          const srcHash = this.pageSourceHash(parsed.content);
+          const srcHash = pageSourceHash(parsed.content);
           const storedHash = existingMeta['addon-source-hash'];
-          const liveHash = this.pageSourceHash(existing.content);
           const hasHash = typeof storedHash === 'string' && storedHash.length > 0;
-          // "unmodified" = the live body is byte-identical to what we last
-          // seeded (⇒ never operator-edited). A legacy page (seeded before the
-          // #920 hash existed) has no stamp — we can't prove it was edited, and
-          // since these are addon-owned pages the operator opted to sync, we
-          // treat it as reseedable too (previous content is kept as a revertable
-          // version, so an old hand-edit is recoverable).
-          const unmodified = hasHash && storedHash === liveHash;
+          // A legacy page (seeded before the #920 hash existed) has no stamp —
+          // treated as reseedable since the previous body is kept as a
+          // revertable version. Used only to pick the log message below.
           const legacy = !hasHash;
-          // Reseed only matters when the live body actually differs from source.
-          const sourceDiffers = srcHash !== liveHash;
+          // #931: single shared evaluator — the Required Pages Sync admin
+          // surface computes status the identical way, so boot + UI cannot
+          // disagree. `outdated` = source changed and the live body is
+          // unmodified-since-seed (or legacy); `locally-modified` = edited, skip.
+          const status = evaluateSeededAddonPage({
+            sourceContent: parsed.content,
+            liveContent: existing.content,
+            storedHash: typeof storedHash === 'string' ? storedHash : undefined
+          });
 
-          if (reseedEnabled && sourceDiffers && (unmodified || legacy)) {
+          if (reseedEnabled && status === 'outdated') {
             // Source is the authority. Merge existing metadata (preserve operator
             // /pipeline extras + original `created`) with the source's declared
             // fields, adopt the source body, keep the UUID, stamp the hash. Goes
@@ -748,7 +750,7 @@ class AddonsManager extends BaseManager {
             logger.info(legacy
               ? `[AddonsManager] Reseeded legacy '${existingSlug}' from ${addonName} (no prior source-hash; previous content kept in version history)`
               : `[AddonsManager] Reseeded '${existingSlug}' from ${addonName} (source changed, page unmodified)`);
-          } else if (reseedEnabled && sourceDiffers && hasHash && !unmodified) {
+          } else if (reseedEnabled && status === 'locally-modified') {
             logger.info(`[AddonsManager] Update available for '${existingSlug}' from ${addonName} but the page was locally modified — skipped`);
           } else {
             logger.debug(`[AddonsManager] Page '${existingSlug}' already seeded — skipping (${addonName})`);
@@ -776,7 +778,7 @@ class AddonsManager extends BaseManager {
           ...(parsed.data as Record<string, unknown>),
           addon: addonName,
           'system-category': (parsed.data as Record<string, unknown>)['system-category'] ?? 'addon',
-          'addon-source-hash': this.pageSourceHash(parsed.content)
+          'addon-source-hash': pageSourceHash(parsed.content)
         };
 
         await pageManager.savePage(slug, parsed.content, metadata);
@@ -802,16 +804,6 @@ class AddonsManager extends BaseManager {
     } else {
       logger.debug(`[AddonsManager] No new pages to seed for ${addonName}`);
     }
-  }
-
-  /**
-   * #920: stable content hash of an addon page's body, used to detect whether an
-   * already-seeded instance page has been operator-edited since seeding. Trimmed
-   * so a trailing-newline difference between source and on-disk form doesn't read
-   * as a modification.
-   */
-  private pageSourceHash(content: string): string {
-    return createHash('sha256').update(String(content).trim()).digest('hex');
   }
 
   /**

--- a/src/routes/WikiRoutes.ts
+++ b/src/routes/WikiRoutes.ts
@@ -26,6 +26,7 @@ import { createPatch } from 'diff';
 import { exec } from 'child_process';
 import { Request, Response, Application } from 'express';
 import SchemaGenerator from '../utils/SchemaGenerator.js';
+import { pageSourceHash, evaluateSeededAddonPage } from '../utils/addonPageSync.js';
 import logger from '../utils/logger.js';
 import LocaleUtils from '../utils/LocaleUtils.js';
 import { extractSection, spliceSection } from '../utils/SectionUtils.js';
@@ -8800,11 +8801,21 @@ ${panes}
               status = 'new';
             } else {
               const destContent: string = await fse.readFile(destPath, 'utf8');
-              const { data: destData } = matter(destContent);
-              userModified = destData['user-modified'] === true;
-              status = normalizeForCompare(sourceContent) !== normalizeForCompare(destContent)
-                ? 'modified'
-                : 'current';
+              const destParsed = matter(destContent) as { data: Record<string, unknown>; content: string };
+              const srcParsed = matter(sourceContent) as { data: Record<string, unknown>; content: string };
+              // #931: identical evaluator + body-only hash the boot pass uses, so
+              // the sync-UI status and the on-boot reseed can never disagree.
+              // `locally-modified` (hash differs from the seed stamp) OR an explicit
+              // `user-modified` flag both mark the page as edit-protected here.
+              const seedStatus = evaluateSeededAddonPage({
+                sourceContent: srcParsed.content,
+                liveContent: destParsed.content,
+                storedHash: typeof destParsed.data['addon-source-hash'] === 'string'
+                  ? (destParsed.data['addon-source-hash'])
+                  : undefined
+              });
+              userModified = destParsed.data['user-modified'] === true || seedStatus === 'locally-modified';
+              status = seedStatus === 'current' ? 'current' : 'modified';
             }
 
             addonComparison.push({ addonName, uuid, title, slug, lastModified, status, userModified });
@@ -8891,19 +8902,32 @@ ${panes}
       // Build a combined UUID → source-file-path map covering both required-pages/ and
       // enabled addon pages/ directories. Required-pages takes precedence on collision.
       const sourceFileMap = new Map<string, string>();
+      // #931: which UUIDs are addon-sourced (→ addon name), so the sync stamps
+      // `addon` + `addon-source-hash` on write and uses hash-based edit
+      // protection — keeping the UI apply consistent with the boot reseed.
+      const addonSourceUuids = new Map<string, string>();
       const addonsManagerPost = this.engine.getManager('AddonsManager');
       if (addonsManagerPost) {
-        for (const { pagesDir } of addonsManagerPost.getEnabledAddonPagesDirectories()) {
+        for (const { name: addonName, pagesDir } of addonsManagerPost.getEnabledAddonPagesDirectories()) {
           if (await fse.pathExists(pagesDir)) {
             for (const f of (await fse.readdir(pagesDir))) {
-              if (f.endsWith('.md')) sourceFileMap.set(path.basename(f, '.md'), path.join(pagesDir, f));
+              if (f.endsWith('.md')) {
+                const u = path.basename(f, '.md');
+                sourceFileMap.set(u, path.join(pagesDir, f));
+                addonSourceUuids.set(u, addonName);
+              }
             }
           }
         }
       }
-      // Required-pages overrides addon pages on UUID collision
+      // Required-pages overrides addon pages on UUID collision (and reclaims the
+      // identity — such a UUID is treated as a required page, not an addon one).
       for (const f of (await fse.readdir(requiredDirResolved))) {
-        if (f.endsWith('.md')) sourceFileMap.set(path.basename(f, '.md'), path.join(requiredDirResolved, f));
+        if (f.endsWith('.md')) {
+          const u = path.basename(f, '.md');
+          sourceFileMap.set(u, path.join(requiredDirResolved, f));
+          addonSourceUuids.delete(u);
+        }
       }
 
       const synced: string[] = [];
@@ -8913,10 +8937,18 @@ ${panes}
        * Write source content to dest, stripping user-modified so a synced page
        * immediately shows as 'current' on the next Required Pages Sync load.
        */
-      const syncFile = async (srcPath: string, dstPath: string): Promise<void> => {
+      const syncFile = async (srcPath: string, dstPath: string, addonName?: string): Promise<void> => {
         const raw: string = await fse.readFile(srcPath, 'utf8');
         const parsed = matter(raw) as { data: Record<string, unknown>; content: string };
         delete parsed.data['user-modified'];
+        // #931: for an addon-sourced page, stamp the provenance + content hash the
+        // boot reseed relies on, so a UI sync leaves the page in the same state a
+        // boot reseed would (otherwise the next boot sees it as legacy/unstamped).
+        if (addonName) {
+          parsed.data['addon'] = addonName;
+          parsed.data['addon-source-hash'] = pageSourceHash(parsed.content);
+          if (!parsed.data['system-category']) parsed.data['system-category'] = 'addon';
+        }
         const cleaned: string = matter.stringify(parsed.content, parsed.data);
         await fse.writeFile(dstPath, cleaned, 'utf8');
       };
@@ -8928,17 +8960,33 @@ ${panes}
         const fileName = `${uuid}.md`;
         const sourcePath = sourceFileMap.get(uuid) ?? path.join(requiredDirResolved, fileName);
         const destPath = path.join(pagesDirResolved, fileName);
+        const addonName = addonSourceUuids.get(uuid);
 
         if (await fse.pathExists(sourcePath)) {
           if (!forceSync && await fse.pathExists(destPath)) {
             const liveRaw: string = await fse.readFile(destPath, 'utf8');
-            const liveParsed = matter(liveRaw) as { data: Record<string, unknown> };
-            if (liveParsed.data['user-modified'] === true) {
+            const liveParsed = matter(liveRaw) as { data: Record<string, unknown>; content: string };
+            let isProtected = liveParsed.data['user-modified'] === true;
+            // #931: addon pages are also protected when the live body diverges
+            // from the seed stamp (hash-based, same signal the boot pass + UI use)
+            // — not only when the explicit user-modified flag is set.
+            if (!isProtected && addonName) {
+              const srcParsed = matter(await fse.readFile(sourcePath, 'utf8')) as { data: Record<string, unknown>; content: string };
+              const st = evaluateSeededAddonPage({
+                sourceContent: srcParsed.content,
+                liveContent: liveParsed.content,
+                storedHash: typeof liveParsed.data['addon-source-hash'] === 'string'
+                  ? (liveParsed.data['addon-source-hash'])
+                  : undefined
+              });
+              isProtected = st === 'locally-modified';
+            }
+            if (isProtected) {
               protected_.push(uuid);
               continue;
             }
           }
-          await syncFile(sourcePath, destPath);
+          await syncFile(sourcePath, destPath, addonName);
           synced.push(uuid);
         }
       }

--- a/src/utils/__tests__/addonPageSync.test.ts
+++ b/src/utils/__tests__/addonPageSync.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the shared addon-page reseed evaluator (#931) — the single source
+ * of truth used by both AddonsManager.seedAddonPages (boot) and the Required
+ * Pages Sync admin surface, so their status/behavior can't diverge.
+ */
+import { describe, expect, test } from 'vitest';
+import { pageSourceHash, evaluateSeededAddonPage } from '../addonPageSync';
+
+describe('pageSourceHash', () => {
+  test('is stable and trims — trailing-newline difference does not change the hash', () => {
+    expect(pageSourceHash('Hello world')).toBe(pageSourceHash('Hello world\n'));
+    expect(pageSourceHash('  Hello world  ')).toBe(pageSourceHash('Hello world'));
+  });
+
+  test('different bodies hash differently', () => {
+    expect(pageSourceHash('v1')).not.toBe(pageSourceHash('v2'));
+  });
+});
+
+describe('evaluateSeededAddonPage (#931)', () => {
+  test('current — live body already matches source', () => {
+    expect(evaluateSeededAddonPage({
+      sourceContent: 'Same body',
+      liveContent: 'Same body',
+      storedHash: pageSourceHash('anything')
+    })).toBe('current');
+  });
+
+  test('current wins even if the stored hash is stale, as long as live == source', () => {
+    // A page synced to source but with an old/absent stamp is still "current".
+    expect(evaluateSeededAddonPage({
+      sourceContent: 'Body',
+      liveContent: 'Body',
+      storedHash: undefined
+    })).toBe('current');
+  });
+
+  test('outdated — source changed and live is unmodified since seed (stored == live)', () => {
+    const seeded = 'Seeded body';
+    expect(evaluateSeededAddonPage({
+      sourceContent: 'New source body',
+      liveContent: seeded,
+      storedHash: pageSourceHash(seeded)
+    })).toBe('outdated');
+  });
+
+  test('outdated — legacy page (no stored hash) is reseedable', () => {
+    expect(evaluateSeededAddonPage({
+      sourceContent: 'New source body',
+      liveContent: 'Old seeded body',
+      storedHash: undefined
+    })).toBe('outdated');
+  });
+
+  test('outdated — empty-string stored hash counts as legacy', () => {
+    expect(evaluateSeededAddonPage({
+      sourceContent: 'New source body',
+      liveContent: 'Old seeded body',
+      storedHash: ''
+    })).toBe('outdated');
+  });
+
+  test('locally-modified — source changed AND live differs from the seed stamp (operator-edited)', () => {
+    expect(evaluateSeededAddonPage({
+      sourceContent: 'New source body',
+      liveContent: 'Operator hand-edited body',
+      storedHash: pageSourceHash('Originally seeded body') // != live hash
+    })).toBe('locally-modified');
+  });
+
+  test('trailing-newline-only divergence is treated as current, not modified', () => {
+    expect(evaluateSeededAddonPage({
+      sourceContent: 'Body text\n',
+      liveContent: 'Body text',
+      storedHash: undefined
+    })).toBe('current');
+  });
+});

--- a/src/utils/addonPageSync.ts
+++ b/src/utils/addonPageSync.ts
@@ -1,0 +1,58 @@
+/**
+ * Single source of truth for addon-seeded page reseed detection (#931).
+ *
+ * Before this module, two independent definitions of "is this addon page
+ * modified?" existed and could disagree:
+ *   - the boot pass (`AddonsManager.seedAddonPages`) used a three-way
+ *     `addon-source-hash` comparison;
+ *   - the Required Pages Sync admin surface (#513) used a source-vs-live
+ *     content normalize plus a `user-modified` frontmatter flag, and never
+ *     read `addon-source-hash` at all.
+ *
+ * Both now call `evaluateSeededAddonPage()` so their status and behavior can
+ * no longer drift. The hash is content-derived (the stronger signal); the
+ * `user-modified` flag remains a secondary manual override at the call sites
+ * that want it.
+ */
+import { createHash } from 'node:crypto';
+
+/**
+ * Stable content hash of an addon page body. Trimmed so a trailing-newline
+ * difference between the source file and the on-disk form does not read as a
+ * modification. This is the value stamped into a seeded page's
+ * `addon-source-hash` frontmatter.
+ */
+export function pageSourceHash(content: string): string {
+  return createHash('sha256').update(String(content).trim()).digest('hex');
+}
+
+/** Reseed status of an addon page that ALREADY exists in the instance. */
+export type SeededAddonPageStatus = 'current' | 'outdated' | 'locally-modified';
+
+/**
+ * Decide what should happen to an already-seeded addon page, given its source
+ * body, its current live body, and the `addon-source-hash` stamped at seed time.
+ *
+ *  - `current`          — live body already matches source; nothing to do.
+ *  - `outdated`         — source changed and the live page is unmodified since
+ *                         seed (stored hash matches live), OR the page is legacy
+ *                         (no stored hash — pre-#920 seed; treated as reseedable
+ *                         since the previous body is kept as a revertable version).
+ *                         Safe to reseed.
+ *  - `locally-modified` — source changed but the live body differs from what was
+ *                         last seeded (⇒ operator-edited). Skip; never clobber.
+ */
+export function evaluateSeededAddonPage(args: {
+  sourceContent: string;
+  liveContent: string;
+  storedHash: string | undefined;
+}): SeededAddonPageStatus {
+  const srcHash = pageSourceHash(args.sourceContent);
+  const liveHash = pageSourceHash(args.liveContent);
+  if (srcHash === liveHash) return 'current';
+
+  const hasHash = typeof args.storedHash === 'string' && args.storedHash.length > 0;
+  const unmodified = hasHash && args.storedHash === liveHash;
+  const legacy = !hasHash;
+  return unmodified || legacy ? 'outdated' : 'locally-modified';
+}


### PR DESCRIPTION
## Summary

Fixes #931. The boot reseed (`AddonsManager.seedAddonPages`) and the Required Pages Sync admin surface (#513) each had their **own** definition of "is this addon page modified?" — they could disagree, and a UI sync wrote addon pages **without** the `addon-source-hash` stamp, degrading the next boot pass to "legacy".

## Fix — one shared evaluator

New `src/utils/addonPageSync.ts`:
- `pageSourceHash()` — trimmed sha256 of the page body (moved out of `AddonsManager`).
- `evaluateSeededAddonPage({sourceContent, liveContent, storedHash})` → `current | outdated | locally-modified`, mirroring the boot decision exactly.

Both callers now use it:
- **Boot pass** delegates its per-page decision to the evaluator — behavior-preserving (72 `AddonsManager` tests green).
- **Sync GET** computes addon-page status via the evaluator on the page **body** with the live `addon-source-hash` → UI status now equals boot behavior. `locally-modified` (hash) OR an explicit `user-modified` flag both mark a page edit-protected.
- **Sync POST** stamps `addon` + `addon-source-hash` when syncing an addon-sourced page (so a UI sync leaves the exact state a boot reseed would), and protects addon pages by the **hash** signal, not only the `user-modified` flag.

## Testing

+9 evaluator tests (current / outdated / legacy / locally-modified / trim-invariance). Full suite **6626 pass**, tsc + `lint:code` clean. jimstest reboots clean; `/admin/required-pages` gated 403 as expected.

## Related
- #920 (parent residual scope), #513 (the sync surface this makes consistent).
- Sibling issues: #929 (docs correction), #930 (removed-source-page policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
