### PR TITLE
feat(addons): removed-source-page policy — flag + opt-in removal (#930)

### DIFF
--- a/src/managers/AddonsManager.ts
+++ b/src/managers/AddonsManager.ts
@@ -1322,6 +1322,83 @@ class AddonsManager extends BaseManager {
   }
 
   /**
+   * #930: addon-seeded instance pages whose source file the addon **no longer
+   * ships** ("source removed"). Leave-and-flag — this only *detects*; nothing is
+   * deleted here. The admin surface surfaces these and offers an opt-in,
+   * versioned removal.
+   *
+   * Enumeration uses the indexed `system-category: addon` (via the search index)
+   * to narrow to addon pages — a small candidate set — instead of scanning the
+   * whole page store. Each candidate is attributed to its addon via the `addon`
+   * frontmatter stamp and diffed against that addon's CURRENT source UUID set.
+   * If search is unavailable, returns `[]` (detection is best-effort, never a
+   * source of deletions).
+   */
+  async findOrphanedAddonPages(): Promise<Array<{
+    addonName: string;
+    uuid: string;
+    slug: string;
+    title: string;
+    userModified: boolean;
+  }>> {
+    const pageManager = this.engine.getManager<PageManager>('PageManager');
+    if (!pageManager) return [];
+    const searchManager = this.engine.getManager<SearchManager>('SearchManager');
+
+    // Current source UUID set for each enabled addon that ships pages.
+    const sourceUuidsByAddon = new Map<string, Set<string>>();
+    for (const { name, pagesDir } of this.getEnabledAddonPagesDirectories()) {
+      const set = new Set<string>();
+      try {
+        for (const f of await fs.promises.readdir(pagesDir)) {
+          if (!f.endsWith('.md')) continue;
+          try {
+            const u = (matter(await fs.promises.readFile(path.join(pagesDir, f), 'utf8')).data.uuid) as string | undefined;
+            if (u) set.add(u);
+          } catch { /* skip unreadable/invalid source file */ }
+        }
+      } catch { /* addon ships no pages/ dir */ }
+      sourceUuidsByAddon.set(name, set);
+    }
+    if (sourceUuidsByAddon.size === 0) return [];
+
+    // Narrow to addon-category pages via the index (cheap); no search ⇒ no detection.
+    let candidateNames: string[] = [];
+    if (searchManager) {
+      try {
+        candidateNames = (await searchManager.searchByCategory('addon'))
+          .map(r => r.name)
+          .filter((n): n is string => typeof n === 'string' && n.length > 0);
+      } catch { candidateNames = []; }
+    }
+
+    const orphans: Array<{ addonName: string; uuid: string; slug: string; title: string; userModified: boolean }> = [];
+    const seen = new Set<string>();
+    for (const name of candidateNames) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const page = await pageManager.getPage(name);
+      if (!page) continue;
+      const meta = (page.metadata as Record<string, unknown> | undefined) ?? {};
+      const addonName = meta.addon as string | undefined;
+      const uuid = (meta.uuid as string | undefined) ?? pageManager.getPageUUID(name) ?? undefined;
+      if (!addonName || !uuid) continue;
+      const sourceSet = sourceUuidsByAddon.get(addonName);
+      if (!sourceSet) continue; // not an enabled addon (or ships no pages) — don't flag
+      if (!sourceSet.has(uuid)) {
+        orphans.push({
+          addonName,
+          uuid,
+          slug: (meta.slug as string) || name,
+          title: (meta.title as string) || name,
+          userModified: meta['user-modified'] === true
+        });
+      }
+    }
+    return orphans;
+  }
+
+  /**
    * Check if an add-on exists (discovered)
    */
   hasAddon(addonName: string): boolean {

--- a/src/managers/__tests__/AddonsManager.test.ts
+++ b/src/managers/__tests__/AddonsManager.test.ts
@@ -1509,4 +1509,80 @@ describe('AddonsManager', () => {
       expect(r.message).toMatch(/not found/i);
     });
   });
+
+  // #930: removed-source-page detection ------------------------------------
+  describe('#930: findOrphanedAddonPages', () => {
+    const uuidKept = '11111111-1111-4111-8111-111111111111';
+    const uuidOrphan = '22222222-2222-4222-8222-222222222222';
+
+    // Engine exposing the managers findOrphanedAddonPages depends on.
+    const makeFullEngine = (configManager, { getPage, searchByCategory }) => ({
+      getManager: vi.fn((name) => {
+        if (name === 'ConfigurationManager') return configManager;
+        if (name === 'PageManager') {
+          return {
+            getPage,
+            getPageUUID: () => null,
+            // seedAddonPages needs these during initialize(); no-op so seeding is quiet.
+            getPageByUUID: async () => null,
+            pageExists: () => false,
+            savePage: async () => {}
+          };
+        }
+        if (name === 'SearchManager') return searchByCategory ? { searchByCategory } : null;
+        return null;
+      })
+    });
+
+    // Addon shipping only the `kept` page in source (uuidOrphan is NOT in source).
+    const seedAddon = async () => {
+      const root = path.join(tmpDir, 'addons');
+      const pagesDir = path.join(root, 'demo', 'pages');
+      await fs.mkdir(pagesDir, { recursive: true });
+      await fs.writeFile(path.join(root, 'demo', 'index.js'),
+        "module.exports = { name: 'demo', version: '1.0.0', register: async () => {} };", 'utf8');
+      await fs.writeFile(path.join(pagesDir, 'kept.md'),
+        `---\nuuid: ${uuidKept}\nslug: kept\ntitle: Kept\n---\nkept body`, 'utf8');
+      return root;
+    };
+
+    test('flags a live addon page whose source was removed; keeps present ones', async () => {
+      const root = await seedAddon();
+      const configManager = makeConfigManager({ addonsPath: [root], enabledAddons: ['demo'] });
+      const getPage = vi.fn(async (name) => {
+        if (name === 'kept') return { content: 'x', metadata: { addon: 'demo', uuid: uuidKept, slug: 'kept', title: 'Kept' } };
+        if (name === 'gone') return { content: 'x', metadata: { addon: 'demo', uuid: uuidOrphan, slug: 'gone', title: 'Gone' } };
+        return null;
+      });
+      const searchByCategory = vi.fn(async () => [{ name: 'kept' }, { name: 'gone' }]);
+
+      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, searchByCategory }));
+      await manager.initialize();
+
+      const orphans = await manager.findOrphanedAddonPages();
+      expect(orphans).toEqual([
+        expect.objectContaining({ addonName: 'demo', uuid: uuidOrphan, slug: 'gone', title: 'Gone' })
+      ]);
+    });
+
+    test('returns [] when the search index is unavailable (best-effort, never guesses deletions)', async () => {
+      const root = await seedAddon();
+      const configManager = makeConfigManager({ addonsPath: [root], enabledAddons: ['demo'] });
+      const getPage = vi.fn(async () => null);
+      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, searchByCategory: null }));
+      await manager.initialize();
+      expect(await manager.findOrphanedAddonPages()).toEqual([]);
+    });
+
+    test('does not flag a page still shipped in source', async () => {
+      const root = await seedAddon();
+      const configManager = makeConfigManager({ addonsPath: [root], enabledAddons: ['demo'] });
+      const getPage = vi.fn(async (name) =>
+        name === 'kept' ? { content: 'x', metadata: { addon: 'demo', uuid: uuidKept, slug: 'kept', title: 'Kept' } } : null);
+      const searchByCategory = vi.fn(async () => [{ name: 'kept' }]);
+      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, searchByCategory }));
+      await manager.initialize();
+      expect(await manager.findOrphanedAddonPages()).toEqual([]);
+    });
+  });
 });

--- a/src/routes/WikiRoutes.ts
+++ b/src/routes/WikiRoutes.ts
@@ -8830,6 +8830,17 @@ ${panes}
         current: addonComparison.filter(p => p.status === 'current').length
       };
 
+      // #930: addon pages whose source the addon no longer ships ("source
+      // removed"). Leave-and-flag — surfaced for the operator, never auto-deleted.
+      let orphanedAddonPages: Array<{ addonName: string; uuid: string; slug: string; title: string; userModified: boolean }> = [];
+      if (addonsManager) {
+        try {
+          orphanedAddonPages = await addonsManager.findOrphanedAddonPages();
+        } catch (orphanErr) {
+          logger.warn(`[adminRequiredPages] orphan detection failed: ${String(orphanErr)}`);
+        }
+      }
+
       const commonData = await this.getCommonTemplateData(req);
       return res.render('admin-required-pages', {
         ...commonData,
@@ -8838,6 +8849,7 @@ ${panes}
         counts,
         addonComparison,
         addonCounts,
+        orphanedAddonPages,
         csrfToken: req.session.csrfToken,
         successMessage: req.query.success || null,
         errorMessage: req.query.error || null
@@ -8886,14 +8898,16 @@ ${panes}
         reconcile?: { sourceUuid: string; liveUuid: string }[];
         adoptUuid?: { sourceUuid: string; liveUuid: string }[];
         pushToSource?: string[];
+        removeOrphans?: string[];
       };
       const uuids = Array.isArray(body.uuids) ? body.uuids : [];
       const forceSync = body.force === true;
       const reconcileItems = Array.isArray(body.reconcile) ? body.reconcile : [];
       const adoptItems = Array.isArray(body.adoptUuid) ? body.adoptUuid : [];
       const pushToSourceUuids = Array.isArray(body.pushToSource) ? body.pushToSource : [];
+      const removeOrphanUuids = Array.isArray(body.removeOrphans) ? body.removeOrphans : [];
 
-      if (uuids.length === 0 && reconcileItems.length === 0 && adoptItems.length === 0 && pushToSourceUuids.length === 0) {
+      if (uuids.length === 0 && reconcileItems.length === 0 && adoptItems.length === 0 && pushToSourceUuids.length === 0 && removeOrphanUuids.length === 0) {
         return res.status(400).json({ success: false, error: 'No pages selected' });
       }
 
@@ -9072,6 +9086,27 @@ ${panes}
         }
       }
 
+      // #930: opt-in removal of orphaned addon pages (source removed). Re-verify
+      // each is CURRENTLY an orphan server-side before deleting — never trust the
+      // client list — and delete via PageManager so a revertable version is kept.
+      const removedOrphans: string[] = [];
+      if (removeOrphanUuids.length > 0) {
+        const addonsMgr = this.engine.getManager('AddonsManager');
+        const currentOrphans = addonsMgr ? await addonsMgr.findOrphanedAddonPages() : [];
+        const orphanUuidSet = new Set(currentOrphans.map((o: { uuid: string }) => o.uuid));
+        const pm = this.engine.getManager('PageManager');
+        for (const uuid of removeOrphanUuids) {
+          if (!orphanUuidSet.has(uuid)) {
+            logger.warn(`[adminSyncRequiredPages] refused orphan removal for ${uuid} — not currently a source-removed addon page`);
+            continue;
+          }
+          if (await pm.deletePage(uuid)) {
+            removedOrphans.push(uuid);
+            logger.info(`[adminSyncRequiredPages] removed orphaned addon page ${uuid} by ${currentUser.username}`);
+          }
+        }
+      }
+
       const pageManager = this.engine.getManager('PageManager');
       await pageManager.refreshPageList();
 
@@ -9100,13 +9135,15 @@ ${panes}
       const parts: string[] = [];
       if (synced.length > 0) parts.push(`${synced.length} page${synced.length !== 1 ? 's' : ''} synced`);
       if (protected_.length > 0) parts.push(`${protected_.length} skipped (user-edited — use Push to Source or diff first)`);
+      if (removedOrphans.length > 0) parts.push(`${removedOrphans.length} orphaned addon page${removedOrphans.length !== 1 ? 's' : ''} removed`);
 
       return res.json({
         success: true,
         message: parts.join('; ') || 'Nothing to sync',
         synced: synced.length,
         uuids: synced,
-        protected: protected_
+        protected: protected_,
+        removedOrphans
       });
     } catch (err: unknown) {
       logger.error('Error syncing required pages:', err);

--- a/views/admin-required-pages.ejs
+++ b/views/admin-required-pages.ejs
@@ -394,6 +394,68 @@
     </div>
     <% } %>
 
+    <!-- Orphaned Addon Pages Section (#930: source removed) -->
+    <% if (typeof orphanedAddonPages !== 'undefined' && orphanedAddonPages.length > 0) { %>
+    <div class="row mt-2">
+        <div class="col-12">
+            <div class="card mb-4 border-danger">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fas fa-unlink me-2 text-danger"></i>Addon Pages — Source Removed</h5>
+                    <small class="text-muted">These pages were seeded by an addon that <strong>no longer ships the source page</strong>.
+                        They are <strong>left in place</strong> (never auto-deleted). Remove one only if you're sure it's obsolete —
+                        removal keeps a revertable version.</small>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0" id="orphanedAddonPagesTable">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Title</th>
+                                    <th>Addon</th>
+                                    <th>Slug</th>
+                                    <th>Note</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <% orphanedAddonPages.forEach(page => { %>
+                                <tr data-uuid="<%= page.uuid %>" class="orphan-row">
+                                    <td>
+                                        <strong><%= page.title %></strong>
+                                        <br><small class="text-muted font-monospace"><%= page.uuid %></small>
+                                    </td>
+                                    <td><span class="badge bg-secondary"><%= page.addonName %></span></td>
+                                    <td><code><%= page.slug || '—' %></code></td>
+                                    <td>
+                                        <span class="badge bg-danger">Source removed</span>
+                                        <% if (page.userModified) { %>
+                                        <br><span class="badge bg-secondary mt-1"><i class="fas fa-user-edit me-1"></i>User Edited</span>
+                                        <% } %>
+                                    </td>
+                                    <td>
+                                        <% if (page.slug) { %>
+                                        <a href="/view/<%= encodeURIComponent(page.slug) %>"
+                                           class="btn btn-sm btn-outline-secondary" target="_blank">
+                                            <i class="fas fa-external-link-alt"></i>
+                                        </a>
+                                        <% } %>
+                                        <button class="btn btn-sm btn-outline-danger"
+                                                onclick="removeOrphan('<%= page.uuid %>', '<%= page.title.replace(/'/g, '\\\'') %>')"
+                                                title="Delete this orphaned page (a revertable version is kept)">
+                                            <i class="fas fa-trash"></i> Remove
+                                        </button>
+                                    </td>
+                                </tr>
+                                <% }); %>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <% } %>
+
     <!-- Diff Modal -->
     <div class="modal fade" id="diffModal" tabindex="-1" aria-labelledby="diffModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-xl modal-dialog-scrollable">
@@ -602,6 +664,34 @@ async function doSync(uuids, statusMsg, force = false) {
             }
             // Reload to update summary badges
             setTimeout(() => location.reload(), 2000);
+        } else {
+            showToast(`✗ Error: ${result.error}`);
+        }
+    } catch (err) {
+        showToast(`✗ Network error: ${err.message}`);
+    }
+}
+
+// #930: remove a single orphaned addon page (source removed). Opt-in, per-row,
+// server re-verifies it's actually an orphan before deleting; keeps a version.
+async function removeOrphan(uuid, title) {
+    if (!confirm(`Remove orphaned addon page "${title}"?\n\nIts addon no longer ships this page. A revertable version is kept, so this can be undone.`)) return;
+    showToast(`Removing "${title}"…`);
+    try {
+        const response = await csrfFetch('/admin/required-pages/sync', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': CSRF_TOKEN
+            },
+            body: JSON.stringify({ removeOrphans: [uuid] })
+        });
+        const result = await response.json();
+        if (result.success) {
+            showToast(`✓ ${result.message}`);
+            const row = document.querySelector(`tr.orphan-row[data-uuid="${uuid}"]`);
+            if (row) row.remove();
+            setTimeout(() => location.reload(), 1500);
         } else {
             showToast(`✗ Error: ${result.error}`);
         }


### PR DESCRIPTION
## Summary

Fixes #930. When an addon ships a new version that **drops** a page it previously seeded, the already-seeded instance page was never surfaced — an orphan of a source that no longer exists. Neither the boot pass nor Required Pages Sync (#513) looked for source-removed pages.

## Fix — leave-and-flag (never auto-delete)

- **`AddonsManager.findOrphanedAddonPages()`** — live addon-owned pages whose UUID is no longer in their addon's current source set. Narrows to candidates via the indexed `system-category: addon` (`searchByCategory`) instead of scanning the whole ~17.8k-page store, attributes each via the `addon` frontmatter stamp, and diffs against the source UUID set. **Best-effort**: no search index ⇒ `[]` (never a source of deletions).
- **Required Pages Sync GET** surfaces them in a new **"Addon Pages — Source Removed"** section — flagged, not touched.
- **Opt-in, per-row removal** — `POST /admin/required-pages/sync` accepts `removeOrphans: [uuid]`; the server **re-verifies** each is currently an orphan before deleting via `PageManager` (a revertable version is kept). Never trusts the client list.

## Why search-index narrowing

The index does not carry an `addon` field, but addon pages are stamped `system-category: addon`, which **is** indexed — so `searchByCategory('addon')` yields a small candidate set to read, avoiding a full-store scan. (Caveat: an addon page whose source overrides `system-category` away from `addon` won't be caught — acceptable for leave-and-flag; documented.)

## Testing

+3 unit tests (flagged when source removed / kept when still shipped / `[]` when search unavailable). Full suite **6629 pass**, tsc + `lint:code` clean. jimstest reboots clean, `/admin/required-pages` gated 403.

## Stacking

Branched off #931 (`feat/931-...`) — shares the sync-surface + evaluator changes. Merge #931 (PR #932) first, or this will carry those commits.

## Related
- #920 (parent residual scope), #513 (sync surface), #931 (detection unification), #929 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
