### PR TITLE
feat(feeds): add exclude= param to [DataFeed] plugin

### DIFF
--- a/addons/feeds/__tests__/DataFeedPlugin.test.ts
+++ b/addons/feeds/__tests__/DataFeedPlugin.test.ts
@@ -233,4 +233,52 @@ describe('[DataFeed] plugin (#685)', () => {
     expect(out).toContain('"lat":4,"lon":4');
     expect(out).not.toContain('"lat":5,"lon":5');
   });
+
+  const activity: NormalizedRecord[] = [
+    { sourceRecordId: 'p1', fetchedAt: 'x', properties: { title: 'Popocatépetl Volcano Volcanic Ash Advisory', summary: 'VAAC: WASHINGTON ... DTG: 20260724/1321Z' } },
+    { sourceRecordId: 'p2', fetchedAt: 'x', properties: { title: 'Volcanoes Today, 24 Jul 2026', summary: 'Etna volcano, Fuego, Krakatau...' } },
+    { sourceRecordId: 'p3', fetchedAt: 'x', properties: { title: 'Sheveluch Volcano Volcanic Ash Advisory', summary: 'VA ADVISORY\nVOLCANO: SHEVELUCH 300270' } }
+  ];
+
+  it('exclude= drops records whose column matches the pattern (geohazardwatch#159)', async () => {
+    const out = await exec(
+      { source: 'q', columns: 'title', exclude: 'summary~VAAC:|VA ADVISORY|DTG:' },
+      activity
+    );
+    expect(out).not.toContain('Popocatépetl');
+    expect(out).not.toContain('Sheveluch');
+    expect(out).toContain('Volcanoes Today');
+  });
+
+  it('exclude= match is case-insensitive', async () => {
+    const out = await exec(
+      { source: 'q', columns: 'title', exclude: 'summary~vaac:' },
+      activity
+    );
+    expect(out).not.toContain('Popocatépetl');
+  });
+
+  it('exclude= with no `~` separator is ignored (no filtering)', async () => {
+    const out = await exec({ source: 'q', columns: 'title', exclude: 'summary VAAC' }, activity);
+    expect(out).toContain('Popocatépetl');
+    expect(out).toContain('Sheveluch');
+    expect(out).toContain('Volcanoes Today');
+  });
+
+  it('exclude= with an invalid regex is ignored (no filtering, no throw)', async () => {
+    const out = await exec({ source: 'q', columns: 'title', exclude: 'summary~(unclosed' }, activity);
+    expect(out).toContain('Popocatépetl');
+  });
+
+  it('exclude= that matches every record still reports "no records"', async () => {
+    const out = await exec({ source: 'q', exclude: 'summary~.' }, activity);
+    expect(out).toContain('no records for feed');
+  });
+
+  it('exclude= referencing a column absent from the record is a no-op match (record kept)', async () => {
+    const out = await exec({ source: 'q', columns: 'title', exclude: 'nonexistent~anything' }, activity);
+    expect(out).toContain('Popocatépetl');
+    expect(out).toContain('Sheveluch');
+    expect(out).toContain('Volcanoes Today');
+  });
 });

--- a/addons/feeds/src/DataFeedPlugin.ts
+++ b/addons/feeds/src/DataFeedPlugin.ts
@@ -16,6 +16,12 @@
  * Params: source (required) · columns (CSV of property keys) · sort
  * ('key' | 'key-asc' | 'key-desc') · max (default 20, 500 for format='map')
  * · format ('table'|'list'|'map')
+ * · exclude ('column~pattern' — a record is dropped when that column's string
+ *   value matches the case-insensitive regex `pattern`; e.g.
+ *   `exclude='summary~VAAC:|VA ADVISORY|DTG:'` drops re-published VAAC
+ *   bulletins from a general news feed, geohazardwatch#159. One rule per
+ *   plugin call — invalid/unparseable exclude params are ignored (no
+ *   filtering), not an error)
  * · lat / lon (property keys holding coordinates, default 'latitude'/'longitude' —
  *   format='map' only; records with a missing/non-numeric value in either are
  *   silently skipped, not an error)
@@ -142,6 +148,25 @@ function resolveLinkTemplate(template: string, properties: Record<string, unknow
 }
 
 /**
+ * Parse `exclude='column~pattern'` into a column + compiled regex. Returns
+ * null on missing/malformed input (no `~`, empty column/pattern, or an
+ * invalid regex) — the caller treats null as "no filtering", never an error.
+ */
+function parseExcludeParam(raw: unknown): { column: string; pattern: RegExp } | null {
+  if (typeof raw !== 'string') return null;
+  const tilde = raw.indexOf('~');
+  if (tilde <= 0) return null;
+  const column = raw.slice(0, tilde).trim();
+  const patternSource = raw.slice(tilde + 1).trim();
+  if (!column || !patternSource) return null;
+  try {
+    return { column, pattern: new RegExp(patternSource, 'i') };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Safely embed a JSON value inside a `<script>` block: escapes any literal
  * `</script` sequence in the serialized output so a record's own text (e.g.
  * an RSS description) can never prematurely close the tag and inject markup.
@@ -193,6 +218,12 @@ const DataFeedPlugin: SimplePlugin = {
     if (!fm?.getRecords) return muted('[DataFeed: feeds addon not available]');
 
     let records = await fm.getRecords(source);
+
+    const exclude = parseExcludeParam(params.exclude);
+    if (exclude) {
+      records = records.filter(r => !exclude.pattern.test(cellString(r.properties[exclude.column])));
+    }
+
     if (records.length === 0) return muted(`[DataFeed: no records for feed '${source}']`);
 
     const columns = typeof params.columns === 'string' && params.columns.trim()


### PR DESCRIPTION
## Summary

Adds a content-based `exclude` filter to the `[DataFeed]` plugin — `exclude='column~pattern'` drops any record whose column matches the case-insensitive regex — matching the existing `badge=`/`link=` declarative-param style already on this plugin.

## Motivation

geohazardwatch#159: the Volcano Activity page's `volcanodiscovery-activity` feed re-publishes NOAA OSPO Washington VAAC bulletins verbatim inside its `description` text (confirmed directly — matching DTG and product code between the two, documented in that repo's `docs/volcano-sources.md`). That content is redundant with the addon's own `VaacDataManager`/`VaacAdvisoriesPlugin` pipeline, which already has it structured and GVP-matched. `exclude='summary~VAAC:|VA ADVISORY|DTG:'` lets that page drop the re-published bulletins and keep only VolcanoDiscovery's original news/digest content — without inventing bespoke addon-side filtering logic for what's really a generic, reusable capability any `DataFeed` consumer might want.

## Design

- Single rule per plugin call: `column~pattern`. Kept intentionally minimal — this is the actual need, and the existing param style (`link='col=template'`) already establishes the `key=value`-ish syntax convention this follows.
- Malformed/unparseable `exclude` (no `~`, empty column/pattern, invalid regex) is a silent no-op — never an error — matching how this plugin already treats other malformed params (e.g. an unresolvable `link` placeholder just renders plain text).
- Applied before the "no records" empty-check, so a fully-excluded result set still reports the existing `no records for feed` message rather than a blank table.

## Testing

6 new tests: drop-matching, case-insensitivity, malformed-param no-ops (no separator, invalid regex), all-excluded still reports empty, absent-column no-op. Full suite: **6632 passed, 9 skipped, 0 failures.** `tsc --noEmit` and `lint:code` clean.

Caught a build-hygiene gotcha along the way, unrelated to this change but worth noting: this addon compiles TS→JS in-place (no separate `dist/`), so a stale compiled `DataFeedPlugin.js` sibling silently shadowed my `.ts` edits during test resolution until `addons/feeds` was rebuilt. Not something this PR changes — just flagging it in case it bites someone else.

## Related

geohazardwatch#159 (the consumer of this param).