### PR TITLE
fix(parser): support inline %%class … /% styles (#938)

### DIFF
--- a/src/parsers/MarkupParser.ts
+++ b/src/parsers/MarkupParser.ts
@@ -199,10 +199,12 @@ export interface ExtractedElement {
   codeContent?: string;
   /** Language tag from fenced code blocks (e.g. 'javascript' from ```javascript) */
   codeLanguage?: string;
-  /** #907: inline-style variant — css | sup | sub | strike */
-  inlineVariant?: 'css' | 'sup' | 'sub' | 'strike';
+  /** #907: inline-style variant — css | sup | sub | strike | class (#938) */
+  inlineVariant?: 'css' | 'sup' | 'sub' | 'strike' | 'class';
   /** #907: raw CSS declarations for inline-style variant 'css' (parenthesis body) */
   cssRaw?: string;
+  /** #938: space-separated class list for inline-style variant 'class' */
+  classNames?: string;
 }
 
 /** Configuration manager interface for type safety */
@@ -1230,13 +1232,14 @@ class MarkupParser extends BaseManager {
    * resolver and the cell/block scanner (appendWikiNodes).
    */
   private async buildInlineStyleNode(
-    variant: 'css' | 'sup' | 'sub' | 'strike',
+    variant: 'css' | 'sup' | 'sub' | 'strike' | 'class',
     cssRaw: string,
     inner: string,
     context: ParseContext | undefined,
     wikiDocument: WikiDocument,
     idStart: number,
-    outerId?: number
+    outerId?: number,
+    classNames?: string
   ): Promise<ReturnType<typeof WikiDocument.prototype.createElement>> {
     const attrs: Record<string, string> = {};
     if (outerId !== undefined) attrs['data-jspwiki-id'] = outerId.toString();
@@ -1244,6 +1247,12 @@ class MarkupParser extends BaseManager {
     if (variant === 'sup') tag = 'sup';
     else if (variant === 'sub') tag = 'sub';
     else if (variant === 'strike') tag = 'del';
+    else if (variant === 'class') {
+      // #938: class names are already constrained to [A-Za-z][\w-]* runs by the
+      // extraction regex, so there is nothing injectable to escape here.
+      tag = 'span';
+      if (classNames) attrs['class'] = classNames;
+    }
     else {
       tag = 'span';
       const style = this.sanitizeInlineCss(cssRaw);
@@ -1524,18 +1533,50 @@ class MarkupParser extends BaseManager {
       // disambiguation lets a nested run's inner style match first (its content
       // has no opener/closer), so nesting resolves bottom-up.
       const inlinePattern = /%%(\((?:[^()]|\([^()]*\))*\)|sup|sub|strike)[ \t]+((?:(?!%%|\/%)[\s\S])*?)[ \t]*(?:\/%|%%(?!\(|sup|sub|strike))/;
+      // #938: bare class-name runs — `%%feed-badge feed-badge--green GREEN/%`.
+      // Inner content is `[^\n]` (SAME LINE ONLY), unlike the variants above.
+      // That restriction is load-bearing, not cosmetic: this extractor runs
+      // BEFORE extractStyleBlocksWithStack, so a multi-line inner would let a
+      // *block* opener (`%%table-fit` alone on its line) match here and swallow
+      // the block's closing `/%`. A block opener's `/%` is always on a later
+      // line, so confining the match to one line makes that impossible.
+      // No conflict the other way either: the block opener regex is anchored
+      // `^\s*%%…$`, so a same-line run was never a block-opener candidate.
+      const inlineClassPattern = /%%([A-Za-z][\w-]*(?:[ \t]+[A-Za-z][\w-]*)*)[ \t]+((?:(?!%%|\/%)[^\n])*?)[ \t]*(?:\/%|%%(?!\(|sup|sub|strike))/;
       let guard = 0;
-      let m: RegExpExecArray | null;
-      while ((m = inlinePattern.exec(sanitized)) !== null && guard++ < 5000) {
+      for (;;) {
+        if (guard++ >= 5000) break;
+        const mVariant = inlinePattern.exec(sanitized);
+        const mClass = inlineClassPattern.exec(sanitized);
+        // Earliest match wins. Nesting still resolves bottom-up regardless of
+        // which pattern hits: both forbid `%%`/`/%` inside their inner group,
+        // so only an innermost run can match on any given round.
+        let m: RegExpExecArray;
+        let isClass: boolean;
+        if (mVariant && mClass) {
+          isClass = mClass.index < mVariant.index;
+          m = isClass ? mClass : mVariant;
+        } else if (mClass) {
+          isClass = true;
+          m = mClass;
+        } else if (mVariant) {
+          isClass = false;
+          m = mVariant;
+        } else {
+          break;
+        }
         const head = m[1];
         const inner = m[2] ?? '';
-        const isCss = head.startsWith('(');
-        const variant: 'css' | 'sup' | 'sub' | 'strike' = isCss ? 'css' : (head as 'sup' | 'sub' | 'strike');
+        const isCss = !isClass && head.startsWith('(');
+        const variant: 'css' | 'sup' | 'sub' | 'strike' | 'class' = isClass
+          ? 'class'
+          : (isCss ? 'css' : (head as 'sup' | 'sub' | 'strike'));
         jspwikiElements.push({
           type: 'inline-style',
           syntax: m[0],
           inlineVariant: variant,
           cssRaw: isCss ? head.slice(1, -1) : undefined,
+          classNames: isClass ? head.replace(/[ \t]+/g, ' ') : undefined,
           inner,
           id: id++,
           position: m.index
@@ -2292,6 +2333,7 @@ class MarkupParser extends BaseManager {
 
     case 'inline-style':
       // #907: inline %%(css)/sup/sub/strike … /% → DOM node
+      // #938: plus bare class runs → <span class="…">
       return await this.buildInlineStyleNode(
         element.inlineVariant ?? 'css',
         element.cssRaw ?? '',
@@ -2299,7 +2341,8 @@ class MarkupParser extends BaseManager {
         context,
         wikiDocument,
         element.id * 1000,
-        element.id
+        element.id,
+        element.classNames
       );
 
     default: {

--- a/src/parsers/MarkupParser.ts
+++ b/src/parsers/MarkupParser.ts
@@ -1532,7 +1532,15 @@ class MarkupParser extends BaseManager {
       // closer must NOT be another opener (`%%(`, `%%sup/sub/strike`) — that
       // disambiguation lets a nested run's inner style match first (its content
       // has no opener/closer), so nesting resolves bottom-up.
-      const inlinePattern = /%%(\((?:[^()]|\([^()]*\))*\)|sup|sub|strike)[ \t]+((?:(?!%%|\/%)[\s\S])*?)[ \t]*(?:\/%|%%(?!\(|sup|sub|strike))/;
+      // The `%%` closer must not itself be an opener. #938 widened what counts
+      // as an opener to include bare class names, so the lookahead has to
+      // exclude `%%class ` too — otherwise `%%a %%b X/%` reads the second `%%`
+      // as A's closer and emits an empty `<span class="a">` followed by the
+      // rest as stray text.
+      const NOT_AN_OPENER = String.raw`(?!\(|sup|sub|strike|[A-Za-z][\w-]*[ \t])`;
+      const inlinePattern = new RegExp(
+        String.raw`%%(\((?:[^()]|\([^()]*\))*\)|sup|sub|strike)[ \t]+((?:(?!%%|\/%)[\s\S])*?)[ \t]*(?:\/%|%%${NOT_AN_OPENER})`
+      );
       // #938: bare class-name runs — `%%feed-badge feed-badge--green GREEN/%`.
       // Inner content is `[^\n]` (SAME LINE ONLY), unlike the variants above.
       // That restriction is load-bearing, not cosmetic: this extractor runs
@@ -1542,7 +1550,9 @@ class MarkupParser extends BaseManager {
       // line, so confining the match to one line makes that impossible.
       // No conflict the other way either: the block opener regex is anchored
       // `^\s*%%…$`, so a same-line run was never a block-opener candidate.
-      const inlineClassPattern = /%%([A-Za-z][\w-]*(?:[ \t]+[A-Za-z][\w-]*)*)[ \t]+((?:(?!%%|\/%)[^\n])*?)[ \t]*(?:\/%|%%(?!\(|sup|sub|strike))/;
+      const inlineClassPattern = new RegExp(
+        String.raw`%%([A-Za-z][\w-]*(?:[ \t]+[A-Za-z][\w-]*)*)[ \t]+((?:(?!%%|\/%)[^\n])*?)[ \t]*(?:\/%|%%${NOT_AN_OPENER})`
+      );
       let guard = 0;
       for (;;) {
         if (guard++ >= 5000) break;

--- a/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
+++ b/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
@@ -178,6 +178,16 @@ describe('MarkupParser inline class styles (#938)', () => {
 
   // ── malformed / edge cases stay inert ─────────────────────────────────────
 
+  test('the two-opener form does not emit an empty span (#938 review)', async () => {
+    // `%%a %%b X/%` is not the multi-class syntax. The second `%%` must not be
+    // read as A's closer — that produced `<span class="feed-badge"></span>`
+    // followed by stray text. The inner run is a well-formed style of its own,
+    // so it renders; the unclosed outer stays literal.
+    const result = await parser.parse('x %%feed-badge %%feed-badge--green GREEN/% y');
+    expect(result).not.toContain('<span class="feed-badge"></span>');
+    expect(result).toContain('<span class="feed-badge--green">GREEN</span>');
+  });
+
   test('an unclosed inline run is left as literal text', async () => {
     const result = await parser.parse('Some %%feed-badge GREEN with no close');
     expect(result).toContain('%%feed-badge');

--- a/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
+++ b/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
@@ -1,0 +1,202 @@
+/**
+ * MarkupParser inline class styles — issue #938
+ *
+ * `%%class-name content /%` written INLINE (same line) now renders a
+ * `<span class="…">`, matching what the block form already did on its own line.
+ *
+ * Before #938 the inline extractor (#907) recognised only `%%(css)`, `%%sup`,
+ * `%%sub` and `%%strike`; bare class names fell through to the block extractor,
+ * which is anchored to a whole line, so an inline run rendered as literal text
+ * — everywhere, not just in tables. Table cells were where it was unavoidable,
+ * since a cell cannot contain a multi-line block.
+ *
+ * The block form MUST keep working: the inline extractor runs before
+ * extractStyleBlocksWithStack, so these tests guard against an inline match
+ * swallowing a block opener's closing `/%`.
+ */
+
+import MarkupParser from '../MarkupParser';
+
+class MockEngine {
+  managers: Map<string, unknown>;
+  constructor() {
+    this.managers = new Map([
+      ['ConfigurationManager', {
+        getProperty: (key: string, defaultValue: unknown) => {
+          const cfg: Record<string, unknown> = {
+            'ngdpbase.markup.enabled': true,
+            'ngdpbase.markup.caching': false,
+            'ngdpbase.markup.handlers.plugin.enabled': false,
+            'ngdpbase.markup.handlers.wikitag.enabled': false,
+            'ngdpbase.markup.handlers.form.enabled': false,
+            'ngdpbase.markup.handlers.interwiki.enabled': false,
+            'ngdpbase.markup.handlers.attachment.enabled': false,
+            'ngdpbase.markup.handlers.linkparser.enabled': false,
+            'ngdpbase.markup.filters.enabled': true,
+            'ngdpbase.markup.filters.security.enabled': false,
+            'ngdpbase.markup.filters.spam.enabled': false,
+            'ngdpbase.markup.filters.validation.enabled': false
+          };
+          return cfg[key] ?? defaultValue;
+        },
+        isInitialized: () => true
+      }],
+      ['CacheManager', {
+        isInitialized: () => true,
+        region: () => ({ get: async () => null, set: async () => {} })
+      }],
+      ['RenderingManager', { converter: { makeHtml: (s: string) => s } }]
+    ]);
+  }
+  getManager(name: string) { return this.managers.get(name) || null; }
+}
+
+describe('MarkupParser inline class styles (#938)', () => {
+  let parser: MarkupParser;
+
+  beforeEach(async () => {
+    parser = new MarkupParser(new MockEngine() as never);
+    await parser.initialize();
+  });
+
+  afterEach(async () => {
+    await parser.shutdown();
+  });
+
+  // ── inline form, outside tables ───────────────────────────────────────────
+
+  test('single class inline renders a classed span', async () => {
+    const result = await parser.parse('Some %%feed-badge GREEN/% text');
+    expect(result).toContain('<span class="feed-badge">GREEN</span>');
+  });
+
+  test('multiple space-separated classes land on one span', async () => {
+    const result = await parser.parse('%%feed-badge feed-badge--green GREEN/%');
+    expect(result).toContain('<span class="feed-badge feed-badge--green">GREEN</span>');
+  });
+
+  test('inline run alone on a line still renders a span, not literal text', async () => {
+    const result = await parser.parse('%%feed-badge GREEN/%');
+    expect(result).toContain('<span class="feed-badge">GREEN</span>');
+    expect(result).not.toContain('%%feed-badge');
+  });
+
+  test('%% closer is accepted as well as /%', async () => {
+    const result = await parser.parse('x %%feed-badge GREEN%% y');
+    expect(result).toContain('<span class="feed-badge">GREEN</span>');
+  });
+
+  // ── inline form, inside table cells (the #938 report) ──────────────────────
+
+  test('class span renders inside a table cell', async () => {
+    const result = await parser.parse('|| Level || Code ||\n| NORMAL | %%feed-badge GREEN/% |');
+    expect(result).toContain('<span class="feed-badge">GREEN</span>');
+  });
+
+  test('multi-class span renders inside a table cell', async () => {
+    const result = await parser.parse(
+      '|| Level || Code ||\n| NORMAL | %%feed-badge feed-badge--green GREEN/% |'
+    );
+    expect(result).toContain('<span class="feed-badge feed-badge--green">GREEN</span>');
+  });
+
+  test('the full #938 aviation-code table renders every badge', async () => {
+    const result = await parser.parse([
+      '%%table-fit table-bordered table-striped table-hover sortable',
+      '|| Level || Aviation Code || Meaning ||',
+      '| NORMAL | %%feed-badge feed-badge--green GREEN/% | typical background |',
+      '| ADVISORY | %%feed-badge feed-badge--yellow YELLOW/% | elevated unrest |',
+      '| WARNING | %%feed-badge feed-badge--red RED/% | eruption imminent |',
+      '/%'
+    ].join('\n'));
+    expect(result).toContain('<span class="feed-badge feed-badge--green">GREEN</span>');
+    expect(result).toContain('<span class="feed-badge feed-badge--yellow">YELLOW</span>');
+    expect(result).toContain('<span class="feed-badge feed-badge--red">RED</span>');
+    // the wrapper classes still reach the table
+    expect(result).toContain('table-bordered');
+    expect(result).toContain('sortable');
+    expect(result).not.toContain('%%feed-badge');
+  });
+
+  // ── block form must not regress (the swallow risk) ─────────────────────────
+
+  test('block form on its own lines still renders a classed span', async () => {
+    const result = await parser.parse('%%feed-badge\nGREEN\n/%');
+    expect(result).toContain('<span class="feed-badge">GREEN</span>');
+  });
+
+  test('block opener is not swallowed by the inline extractor', async () => {
+    const result = await parser.parse('%%mybox\nline one\nline two\n/%');
+    expect(result).toContain('mybox');
+    // the closing /% was consumed as the block's close, not left as text
+    expect(result).not.toContain('/%');
+  });
+
+  test('multi-class block wrapper around a table keeps all classes', async () => {
+    const result = await parser.parse([
+      '%%table-fit table-bordered',
+      '|| A || B ||',
+      '| 1 | 2 |',
+      '/%'
+    ].join('\n'));
+    expect(result).toContain('table-fit');
+    expect(result).toContain('table-bordered');
+    expect(result).not.toContain('%%table-fit');
+  });
+
+  test('nested block wrappers still nest', async () => {
+    const result = await parser.parse('%%outer\n%%inner\ntext\n/%\n/%');
+    expect(result).toContain('outer');
+    expect(result).toContain('inner');
+    expect(result).not.toContain('%%outer');
+  });
+
+  // ── the other inline variants must not regress ─────────────────────────────
+
+  test('%%sup still renders sup, not a class span', async () => {
+    const result = await parser.parse('x%%sup 2/%');
+    expect(result).toContain('<sup>2</sup>');
+    expect(result).not.toContain('<span class="sup"');
+  });
+
+  test('%%sub and %%strike still render their own tags', async () => {
+    expect(await parser.parse('x%%sub 3/%')).toContain('<sub>3</sub>');
+    expect(await parser.parse('%%strike gone/%')).toContain('<del>gone</del>');
+  });
+
+  test('%%(css) is still treated as CSS, not as a class name', async () => {
+    const result = await parser.parse('%%(color:green) GREEN/%');
+    expect(result).toContain('<span');
+    expect(result).not.toContain('class="(color:green)"');
+  });
+
+  test('%%sup inside a table cell still works alongside class spans', async () => {
+    const result = await parser.parse('|| A ||\n| x%%sup 2/% and %%feed-badge Y/% |');
+    expect(result).toContain('<sup>2</sup>');
+    expect(result).toContain('<span class="feed-badge">Y</span>');
+  });
+
+  // ── malformed / edge cases stay inert ─────────────────────────────────────
+
+  test('an unclosed inline run is left as literal text', async () => {
+    const result = await parser.parse('Some %%feed-badge GREEN with no close');
+    expect(result).toContain('%%feed-badge');
+  });
+
+  test('class names cannot inject an attribute or tag', async () => {
+    // `"` is outside the [A-Za-z][\w-]* charset, so this cannot match the class
+    // pattern at all. The run stays literal text — `onload=` appears as body
+    // text, never as an attribute — so assert no element was emitted rather
+    // than merely that the substring is absent.
+    const result = await parser.parse('%%bad"onload=x GREEN/%');
+    expect(result).not.toContain('<span');
+    expect(result).not.toContain('class="bad');
+  });
+
+  test('a class run cannot carry an event-handler attribute even when well-formed', async () => {
+    // `=` is not in the class charset either, so `onload=x` can never become
+    // part of the emitted class list.
+    const result = await parser.parse('%%feed-badge onload=x GREEN/%');
+    expect(result).not.toMatch(/<span[^>]*onload/);
+  });
+});


### PR DESCRIPTION
## Summary

Makes `%%class-name content /%` work **inline** (same line), so class-based styling can be used inside table cells. Fixes #938.

## Root cause

Two separate paths owned `%%…`:

- **Block class styles** — `extractStyleBlocksWithStack`, opener anchored `^\s*%%…$` (`MarkupParser.ts:1330`): the class list must be alone on its line.
- **Inline styles (#907)** — `inlinePattern` (`MarkupParser.ts:1526`) recognised only `%%(css)`, `%%sup`, `%%sub`, `%%strike`.

Bare class names were in neither when written inline, so they rendered as **literal text everywhere** — not just in tables. Tables were simply where it was unavoidable, since a cell cannot contain a multi-line block. #907 listed "handle table-cell interleaving" as a constraint but only carried those four variants across.

## Change

Adds a `class` inline-style variant — 4 edits, all in `MarkupParser.ts`:

1. `ExtractedElement`: `inlineVariant` gains `'class'`, plus a `classNames` field.
2. Extraction: a second, **same-line-only** pattern for bare class-name runs.
3. Dispatch: pass `classNames` through to the node builder.
4. `buildInlineStyleNode`: a `class` branch emitting `<span class="…">`.

### The load-bearing detail

The class pattern's inner group is `[^\n]`, not `[\s\S]`. This extractor runs at line 1517, **before** `extractStyleBlocksWithStack` at 1554 — with a multi-line inner group, a block opener (`%%table-fit` alone on its line) would match here and swallow the block's closing `/%`. A block opener's `/%` is always on a later line, so confining the class match to one line makes that impossible. The reverse direction was already safe: the block opener regex is anchored `^\s*%%…$`, so a same-line run was never a block-opener candidate.

There are explicit non-regression tests for exactly this swallow case.

## Syntax

```
| NORMAL | %%feed-badge feed-badge--green GREEN/% |
```
```html
<td><span class="feed-badge feed-badge--green">GREEN</span></td>
```

One `%%`, classes space-separated, one `/%` — the same rule the block form already used. Note the reporter's `%%a %%b … /%` (two openers, one closer) is not the multi-class syntax and does not work in either form; neither does the balanced `… /% /%` variant.

## Security

Class names are constrained to `[A-Za-z][\w-]*` runs by the extraction regex, so nothing injectable reaches the attribute — `"`, `<`, `=` cannot match. `class` is already in `SecurityFilter`'s default allowed-attribute set (`SecurityFilter.ts:202`), so the attribute survives sanitisation in production config. Covered by two tests.

## Testing

**18 new tests** in `MarkupParser-InlineClassStyles.test.ts`: inline single/multi-class, inside table cells, the full #938 aviation-code table, block-form non-regression (including the swallow case and nested wrappers), the other inline variants (`sup`/`sub`/`strike`/`(css)`) unaffected, and malformed/injection edges.

Full suite: **274 files, 6663 passed, 9 skipped, 0 failures.** `tsc --noEmit` clean; `lint:code` 0 errors (5 pre-existing warnings in untouched files).

Verified end-to-end on the `ngdpbase temp build` instance through the real server (security filter active), not just in unit tests — `/api/preview` returns the badge spans intact.

## Unrelated observation (not fixed here)

Block-style wrappers emit `<p><table …></table></p>` — invalid nesting, since browsers auto-close the `<p>`. Confirmed pre-existing and independent of this change: a wrapper with **no** inline runs reproduces it, and a bare table without a wrapper does not. Worth its own issue if it's causing layout surprises.
