### PR TITLE
fix(deps): bump minimatch to v10 so brace-expansion resolves to patched 5.0.8 (#955)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngdpbase",
-  "version": "3.66.0",
+  "version": "3.68.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngdpbase",
-      "version": "3.66.0",
+      "version": "3.68.1",
       "license": "ISC",
       "dependencies": {
         "@elastic/elasticsearch": "^8.19.1",
@@ -38,7 +38,7 @@
         "lunr": "^2.3.9",
         "markdownlint": "^0.38.0",
         "micromatch": "^4.0.8",
-        "minimatch": "^9.0.9",
+        "minimatch": "^10.2.5",
         "multer": "^2.2.0",
         "node-cache": "^5.1.2",
         "nodemailer": "^9.0.1",
@@ -3111,6 +3111,22 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -8156,18 +8172,39 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/ms": {
@@ -10582,6 +10619,22 @@
       },
       "peerDependencies": {
         "typedoc": "0.28.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "lunr": "^2.3.9",
     "markdownlint": "^0.38.0",
     "micromatch": "^4.0.8",
-    "minimatch": "^9.0.9",
+    "minimatch": "^10.2.5",
     "multer": "^2.2.0",
     "node-cache": "^5.1.2",
     "nodemailer": "^9.0.1",


### PR DESCRIPTION
## Summary

Moves the runtime `brace-expansion` onto the patched **5.0.8**, closing CVE-2026-14257 / GHSA-mh99-v99m-4gvg (high — DoS via unbounded expansion causing an OOM crash). Fixes #955.

One-line change: `minimatch` `^9.0.9` → `^10`.

## Why the "no upgrade path" reading was wrong

The advisory says vulnerable `<= 5.0.7`, fixed in `5.0.8`, while the installed copies were on the `1.x` and `2.x` lines — four majors below the patch, with `brace-expansion` never a direct dependency. That looks like it needs a global `overrides` entry crossing four majors, or waiting on upstream.

It doesn't. **Every path runs through `minimatch`, and `minimatch` is ours** — a direct dependency, imported by `FileSystemMediaProvider` and `addonsPathResolver`. `minimatch@10` depends on `brace-expansion: ^5.0.5`, so bumping our own dependency resolves it cleanly.

### Production tree

Before:

```text
ejs -> jake -> filelist -> minimatch@5.1.9  -> brace-expansion@2.1.2
minimatch@9.0.9                             -> brace-expansion@2.1.2
```

After:

```text
ejs -> jake -> filelist -> minimatch@5.1.9  -> brace-expansion@2.1.2
minimatch@10.2.5                            -> brace-expansion@5.0.8
```

## What remains, and why it is acceptable

- **`ejs -> jake -> filelist -> minimatch@5.1.9`** — still on `2.1.2`, and not fixable from here. Not reachable either: `jake`/`filelist` serve ejs's own build tooling, never its template rendering, which is all we call (`res.render`).
- **Three copies of `1.1.16`** — all eslint's, dev-only, never shipped.

## Reachability, assessed before choosing a fix

The flaw is in expanding the **pattern**, not the string being tested. Both our call sites take patterns from operator-controlled sources:

- `addonsPathResolver` — globs from the `addons-path` config
- `FileSystemMediaProvider` — patterns from `.ngdpbaseignore` files inside the operator's own media tree

No web or user input reaches `minimatch`. So this was **hygiene rather than an exposed hole** — which is precisely why it was worth fixing properly with a supported upgrade rather than forcing a risky `overrides` entry across four majors.

## Testing

- `tsc --noEmit` clean, `lint:code` 0 errors
- Full suite **6718 passed**, build clean
- Live: jimstest restarted, serving 200, addons initialise normally
- Direct behavioural check of the eight glob shapes our two call sites actually use — wildcards, exact names, dotfile handling, `*-addon` scoping, and brace expansion itself — all match v9 semantics:

```text
ok  "photo.jpg"     vs "*.jpg"      -> true
ok  "photo.png"     vs "*.jpg"      -> false
ok  "thumbs"        vs "thumbs"     -> true
ok  ".hidden"       vs "*"          -> false
ok  "claude-addon"  vs "*-addon"    -> true
ok  "other"         vs "*-addon"    -> false
ok  "a.txt"         vs "{a,b}.txt"  -> true
ok  "c.txt"         vs "{a,b}.txt"  -> false
```

That last pair matters most — brace expansion is the changed code path.
