### PR TITLE
fix(deps): bump ejs to v6, removing the last vulnerable brace-expansion (#955)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "cookie-parser": "^1.4.7",
         "diff": "^8.0.3",
         "diff2html": "^3.4.56",
-        "ejs": "^3.1.10",
+        "ejs": "^6.0.1",
         "exiftool-vendored": "^35.19.0",
         "express": "^5.2.1",
         "express-session": "^1.18.2",
@@ -3631,6 +3631,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3785,6 +3786,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4705,18 +4707,15 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-6.0.1.tgz",
+      "integrity": "sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
       "bin": {
         "ejs": "bin/cli.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.12.18"
       }
     },
     "node_modules/enabled": {
@@ -5591,27 +5590,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -6578,23 +6556,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jose": {
@@ -8736,6 +8697,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "cookie-parser": "^1.4.7",
     "diff": "^8.0.3",
     "diff2html": "^3.4.56",
-    "ejs": "^3.1.10",
+    "ejs": "^6.0.1",
     "exiftool-vendored": "^35.19.0",
     "express": "^5.2.1",
     "express-session": "^1.18.2",


### PR DESCRIPTION
## Summary

Completes #955 by removing the **last** vulnerable `brace-expansion` from the production tree. One-line change: `ejs` `^3.1.10` → `^6`.

## Correcting the previous claim

#957 moved our own `minimatch` path to the patched `brace-expansion@5.0.8`, but left a vulnerable `2.1.2` behind via `ejs -> jake -> filelist -> minimatch@5.1.9`. I described that residual as *"not fixable from here"* and proposed carrying #955 open at P2 indefinitely.

That was wrong. Two facts settle it:

- `filelist@2.0.2` depends on `minimatch: ^10.2.1`
- **`ejs@6.0.1` has no dependencies at all** — it dropped `jake` entirely

`ejs` is our own direct dependency, so bumping it removes the whole subtree.

### Production tree

Before:

```text
ejs -> jake -> filelist -> minimatch@5.1.9  -> brace-expansion@2.1.2
minimatch@10.2.5                            -> brace-expansion@5.0.8
```

After:

```text
minimatch@10.2.5                            -> brace-expansion@5.0.8
```

`npm audit --omit=dev` is now down to the two known `showdown` moderates (#599, upstream-blocked). **No `brace-expansion` exposure remains in production.**

## Risk, and how it was checked

`ejs` 3 → 6 is three majors on the engine that renders every view, so this is the part worth reviewing rather than the dependency arithmetic.

Mitigating factor: **we never touch the ejs API directly.** It is registered as the express view engine (`app.ts:133`) and nothing else. The exposed surface is therefore template syntax, not library calls.

Verification:

| Check | Result |
|---|---|
| Unit suite | 6718 passed |
| E2E (real browser: every view, logins, admin, plugins) | 80 passed |
| All templates compile under ejs 6 | 84/84 — 71 core + 13 addon |
| Smoke: `/view/Welcome`, `/profile`, `/admin` | 200, 200, 403 (auth, correct) |
| Render errors in logs | none |
| `tsc --noEmit`, `lint:code` | clean |

The template compile check matters because E2E does not exercise every one of the 84 templates — several addon views and error pages are only reachable in specific states.

## Residual risk

A three-major bump can still differ at runtime in ways neither compilation nor the covered E2E paths reach — for example a rarely-rendered error template, or an addon view behind a feature flag that is off here. Worth a look at the journal/calendar/forms addon screens on a running instance if you want that closed off; they compile, but only some are E2E-covered.
