### PR TITLE
fix(addons): key orphan detection on the indexed `addon` stamp (addons.md item 12)

### DIFF
--- a/src/managers/AddonsManager.ts
+++ b/src/managers/AddonsManager.ts
@@ -384,6 +384,17 @@ class AddonsManager extends BaseManager {
     await this.discoverAddons();
     await this.loadAddons();
 
+    // Runs after loading so every enabled addon's pages/ dir is known. Cheap —
+    // walks only addon source pages, never the whole page tree — and makes
+    // orphan detection work on instances seeded before `addon` was indexed.
+    try {
+      await this.backfillIndexAddonStamps();
+    } catch (err) {
+      // Never let a back-fill failure block startup; detection simply stays
+      // as blind as it was before.
+      logger.warn('[AddonsManager] Could not back-fill addon index stamps:', err);
+    }
+
     logger.info(
       `Initialized with ${this.addons.size} add-on(s) discovered, ` +
         `${this.getLoadedCount()} loaded`
@@ -1343,7 +1354,8 @@ class AddonsManager extends BaseManager {
   }>> {
     const pageManager = this.engine.getManager<PageManager>('PageManager');
     if (!pageManager) return [];
-    const searchManager = this.engine.getManager<SearchManager>('SearchManager');
+    // Deliberately no SearchManager dependency — see the candidate-selection
+    // comment below.
 
     // Current source UUID set for each enabled addon that ships pages.
     const sourceUuidsByAddon = new Map<string, Set<string>>();
@@ -1362,40 +1374,76 @@ class AddonsManager extends BaseManager {
     }
     if (sourceUuidsByAddon.size === 0) return [];
 
-    // Narrow to addon-category pages via the index (cheap); no search ⇒ no detection.
-    let candidateNames: string[] = [];
-    if (searchManager) {
-      try {
-        candidateNames = (await searchManager.searchByCategory('addon'))
-          .map(r => r.name)
-          .filter((n): n is string => typeof n === 'string' && n.length > 0);
-      } catch { candidateNames = []; }
-    }
+    // Candidates come from the page index's `addon` stamp, not from
+    // `searchByCategory('addon')`.
+    //
+    // The category route had two holes: a seeded page declaring any other
+    // `system-category` (the `forms` page declares `documentation`) was never a
+    // candidate, and when SearchManager was unavailable detection silently
+    // returned nothing. The §9 re-categorisation would have widened the first
+    // hole further. `addon` is stamped unconditionally by the seeder, so it is
+    // the reliable discriminator.
+    const indexed = pageManager.getAddonSeededIndexEntries();
 
     const orphans: Array<{ addonName: string; uuid: string; slug: string; title: string; userModified: boolean }> = [];
     const seen = new Set<string>();
-    for (const name of candidateNames) {
-      if (seen.has(name)) continue;
-      seen.add(name);
-      const page = await pageManager.getPage(name);
-      if (!page) continue;
-      const meta = (page.metadata as Record<string, unknown> | undefined) ?? {};
-      const addonName = meta.addon as string | undefined;
-      const uuid = (meta.uuid as string | undefined) ?? pageManager.getPageUUID(name) ?? undefined;
-      if (!addonName || !uuid) continue;
-      const sourceSet = sourceUuidsByAddon.get(addonName);
+    for (const entry of indexed) {
+      if (seen.has(entry.uuid)) continue;
+      seen.add(entry.uuid);
+      const sourceSet = sourceUuidsByAddon.get(entry.addon);
       if (!sourceSet) continue; // not an enabled addon (or ships no pages) — don't flag
-      if (!sourceSet.has(uuid)) {
-        orphans.push({
-          addonName,
-          uuid,
-          slug: (meta.slug as string) || name,
-          title: (meta.title as string) || name,
-          userModified: meta['user-modified'] === true
-        });
-      }
+      if (sourceSet.has(entry.uuid)) continue; // still shipped upstream
+
+      // Only read the page for the few that are actually orphaned, to pick up
+      // `user-modified` — the index does not carry it.
+      let userModified = false;
+      try {
+        const page = await pageManager.getPage(entry.slug || entry.title);
+        const meta = (page?.metadata as Record<string, unknown> | undefined) ?? {};
+        userModified = meta['user-modified'] === true;
+      } catch { /* page unreadable — still report it as orphaned */ }
+
+      orphans.push({
+        addonName: entry.addon,
+        uuid: entry.uuid,
+        slug: entry.slug || entry.title,
+        title: entry.title,
+        userModified
+      });
     }
     return orphans;
+  }
+
+  /**
+   * Back-fill the page index's `addon` stamp for pages seeded before the field
+   * was indexed.
+   *
+   * Without this, orphan detection is blind on any existing instance: the field
+   * is written on save, and seeded pages are deliberately not re-saved once
+   * they exist. Cheap — it walks only each addon's own source pages (tens of
+   * files), never the whole page tree.
+   */
+  private async backfillIndexAddonStamps(): Promise<void> {
+    const pageManager = this.engine.getManager<PageManager>('PageManager');
+    if (!pageManager?.setIndexAddon) return;
+
+    let stamped = 0;
+    for (const { name, pagesDir } of this.getEnabledAddonPagesDirectories()) {
+      let files: string[] = [];
+      try {
+        files = (await fs.promises.readdir(pagesDir)).filter(f => f.endsWith('.md'));
+      } catch { continue; }
+      for (const f of files) {
+        try {
+          const uuid = matter(await fs.promises.readFile(path.join(pagesDir, f), 'utf8')).data.uuid as string | undefined;
+          if (!uuid) continue;
+          if (await pageManager.setIndexAddon(uuid, name)) stamped++;
+        } catch { /* skip unreadable source file */ }
+      }
+    }
+    if (stamped > 0) {
+      logger.info(`[AddonsManager] Back-filled 'addon' index stamp on ${stamped} seeded page(s)`);
+    }
   }
 
   /**

--- a/src/managers/PageManager.ts
+++ b/src/managers/PageManager.ts
@@ -1009,6 +1009,29 @@ class PageManager extends BaseManager implements CatalogSource {
   }
 
   /**
+   * Every indexed page carrying an `addon` provenance stamp.
+   * Used by addon orphan detection; reads the in-memory index, no disk I/O.
+   * Returns [] on providers that do not maintain a page index.
+   */
+  getAddonSeededIndexEntries(): Array<{ uuid: string; addon: string; slug?: string; title: string }> {
+    const p = this.provider as unknown as {
+      getAddonSeededIndexEntries?: () => Array<{ uuid: string; addon: string; slug?: string; title: string }>;
+    } | null;
+    return p?.getAddonSeededIndexEntries?.() ?? [];
+  }
+
+  /**
+   * Set the `addon` stamp on an existing index entry without rewriting the page.
+   * Used by the boot-time back-fill. Returns false when unsupported or unchanged.
+   */
+  async setIndexAddon(uuid: string, addonName: string): Promise<boolean> {
+    const p = this.provider as unknown as {
+      setIndexAddon?: (uuid: string, addonName: string) => Promise<boolean>;
+    } | null;
+    return (await p?.setIndexAddon?.(uuid, addonName)) ?? false;
+  }
+
+  /**
    * Pages owned by a given user (#640).
    *
    * Authorization: callers MUST verify the requesting user is allowed to ask

--- a/src/managers/__tests__/AddonsManager.test.ts
+++ b/src/managers/__tests__/AddonsManager.test.ts
@@ -1516,13 +1516,20 @@ describe('AddonsManager', () => {
     const uuidOrphan = '22222222-2222-4222-8222-222222222222';
 
     // Engine exposing the managers findOrphanedAddonPages depends on.
-    const makeFullEngine = (configManager, { getPage, searchByCategory }) => ({
+    //
+    // Candidates now come from the page index's `addon` stamp
+    // (getAddonSeededIndexEntries), NOT from searchByCategory('addon'). The
+    // SearchManager slot is retained only to prove detection no longer depends
+    // on it.
+    const makeFullEngine = (configManager, { getPage, indexEntries = [], searchByCategory = null }) => ({
       getManager: vi.fn((name) => {
         if (name === 'ConfigurationManager') return configManager;
         if (name === 'PageManager') {
           return {
             getPage,
             getPageUUID: () => null,
+            getAddonSeededIndexEntries: () => indexEntries,
+            setIndexAddon: async () => false,
             // seedAddonPages needs these during initialize(); no-op so seeding is quiet.
             getPageByUUID: async () => null,
             pageExists: () => false,
@@ -1554,9 +1561,12 @@ describe('AddonsManager', () => {
         if (name === 'gone') return { content: 'x', metadata: { addon: 'demo', uuid: uuidOrphan, slug: 'gone', title: 'Gone' } };
         return null;
       });
-      const searchByCategory = vi.fn(async () => [{ name: 'kept' }, { name: 'gone' }]);
+      const indexEntries = [
+        { uuid: uuidKept, addon: 'demo', slug: 'kept', title: 'Kept' },
+        { uuid: uuidOrphan, addon: 'demo', slug: 'gone', title: 'Gone' }
+      ];
 
-      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, searchByCategory }));
+      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, indexEntries }));
       await manager.initialize();
 
       const orphans = await manager.findOrphanedAddonPages();
@@ -1565,11 +1575,59 @@ describe('AddonsManager', () => {
       ]);
     });
 
-    test('returns [] when the search index is unavailable (best-effort, never guesses deletions)', async () => {
+    test('detects orphans with NO SearchManager at all', async () => {
+      // Previously this asserted the opposite — no search meant no detection,
+      // which silently disabled the feature whenever search was unavailable.
+      // Candidates now come from the page index, so search is irrelevant.
       const root = await seedAddon();
       const configManager = makeConfigManager({ addonsPath: [root], enabledAddons: ['demo'] });
       const getPage = vi.fn(async () => null);
-      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, searchByCategory: null }));
+      const indexEntries = [{ uuid: uuidOrphan, addon: 'demo', slug: 'gone', title: 'Gone' }];
+      const manager = new AddonsManager(
+        makeFullEngine(configManager, { getPage, indexEntries, searchByCategory: null })
+      );
+      await manager.initialize();
+      expect(await manager.findOrphanedAddonPages()).toEqual([
+        expect.objectContaining({ addonName: 'demo', uuid: uuidOrphan, slug: 'gone' })
+      ]);
+    });
+
+    test('detects an orphan whose system-category is NOT "addon"', async () => {
+      // The hole this replaced: searchByCategory('addon') never saw a seeded
+      // page declaring another category — addons/forms ships one declaring
+      // `documentation`. The index stamp is category-independent.
+      const root = await seedAddon();
+      const configManager = makeConfigManager({ addonsPath: [root], enabledAddons: ['demo'] });
+      const getPage = vi.fn(async () => ({
+        content: 'x',
+        metadata: { addon: 'demo', uuid: uuidOrphan, slug: 'gone', title: 'Gone', 'system-category': 'documentation' }
+      }));
+      const indexEntries = [{ uuid: uuidOrphan, addon: 'demo', slug: 'gone', title: 'Gone' }];
+      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, indexEntries }));
+      await manager.initialize();
+      expect(await manager.findOrphanedAddonPages()).toHaveLength(1);
+    });
+
+    test('carries user-modified through from the page', async () => {
+      const root = await seedAddon();
+      const configManager = makeConfigManager({ addonsPath: [root], enabledAddons: ['demo'] });
+      const getPage = vi.fn(async () => ({
+        content: 'x',
+        metadata: { addon: 'demo', uuid: uuidOrphan, slug: 'gone', title: 'Gone', 'user-modified': true }
+      }));
+      const indexEntries = [{ uuid: uuidOrphan, addon: 'demo', slug: 'gone', title: 'Gone' }];
+      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, indexEntries }));
+      await manager.initialize();
+      const orphans = await manager.findOrphanedAddonPages();
+      expect(orphans[0].userModified).toBe(true);
+    });
+
+    test('ignores index entries belonging to an addon that is not enabled', async () => {
+      const root = await seedAddon();
+      const configManager = makeConfigManager({ addonsPath: [root], enabledAddons: ['demo'] });
+      const getPage = vi.fn(async () => null);
+      const indexEntries = [{ uuid: uuidOrphan, addon: 'some-other-addon', slug: 'gone', title: 'Gone' }];
+      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, indexEntries }));
       await manager.initialize();
       expect(await manager.findOrphanedAddonPages()).toEqual([]);
     });
@@ -1579,8 +1637,8 @@ describe('AddonsManager', () => {
       const configManager = makeConfigManager({ addonsPath: [root], enabledAddons: ['demo'] });
       const getPage = vi.fn(async (name) =>
         name === 'kept' ? { content: 'x', metadata: { addon: 'demo', uuid: uuidKept, slug: 'kept', title: 'Kept' } } : null);
-      const searchByCategory = vi.fn(async () => [{ name: 'kept' }]);
-      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, searchByCategory }));
+      const indexEntries = [{ uuid: uuidKept, addon: 'demo', slug: 'kept', title: 'Kept' }];
+      const manager = new AddonsManager(makeFullEngine(configManager, { getPage, indexEntries }));
       await manager.initialize();
       expect(await manager.findOrphanedAddonPages()).toEqual([]);
     });

--- a/src/providers/VersioningFileProvider.ts
+++ b/src/providers/VersioningFileProvider.ts
@@ -50,6 +50,22 @@ interface PageIndexEntry {
   audienceRoles?: string[];
   /** True when the page's frontmatter has `private: true` (canonical since #639 Slice E / v3.7.0) */
   isPrivate?: boolean;
+  /**
+   * Name of the add-on that seeded this page, mirrored from `PageFrontmatter.addon`.
+   *
+   * Indexed so provenance can be queried without reading every page file — the
+   * orphan detector previously narrowed candidates via
+   * `searchByCategory('addon')`, which missed any seeded page carrying a
+   * different `system-category` (e.g. the `forms` page declaring
+   * `documentation`) and returned nothing at all when SearchManager was
+   * unavailable.
+   *
+   * Optional because indexes written before this field exists will not have it;
+   * page frontmatter remains the source of truth, and entries gain it on their
+   * next save. `AddonsManager` back-fills seeded pages at boot so detection is
+   * not blind on existing instances.
+   */
+  addon?: string;
 }
 
 /**
@@ -751,6 +767,45 @@ class VersioningFileProvider extends FileSystemProvider {
    * that includes editor / currentVersion / hasVersions — fields the
    * RecentChangesPlugin's "full" format needs. Same visibility rules.
    */
+  /**
+   * Every indexed page carrying an `addon` provenance stamp.
+   *
+   * Reads the in-memory page index — no disk I/O and no dependency on
+   * SearchManager. That matters: the orphan detector used to narrow candidates
+   * with `searchByCategory('addon')`, which both missed seeded pages carrying a
+   * different `system-category` and returned nothing at all when search was
+   * unavailable.
+   *
+   * Entries written before `addon` was indexed simply will not appear;
+   * `AddonsManager` back-fills seeded pages at boot.
+   */
+  getAddonSeededIndexEntries(): Array<{ uuid: string; addon: string; slug?: string; title: string }> {
+    if (!this.pageIndex) return [];
+    const out: Array<{ uuid: string; addon: string; slug?: string; title: string }> = [];
+    for (const entry of Object.values(this.pageIndex.pages)) {
+      if (typeof entry.addon === 'string' && entry.addon.length > 0) {
+        out.push({ uuid: entry.uuid, addon: entry.addon, slug: entry.slug, title: entry.title });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Set the `addon` stamp on an existing index entry without rewriting the page.
+   * Used by the boot-time back-fill so detection works on instances whose pages
+   * were seeded before the field existed.
+   *
+   * Returns true when the entry was found and changed.
+   */
+  async setIndexAddon(uuid: string, addonName: string): Promise<boolean> {
+    if (!this.pageIndex) return false;
+    const entry = this.pageIndex.pages[uuid];
+    if (!entry || entry.addon === addonName) return false;
+    entry.addon = addonName;
+    await this.savePageIndex();
+    return true;
+  }
+
   async getRecentChanges(options: RecentChangesOptions = {}): Promise<RecentChangeEntry[]> {
     if (!this.pageIndex) {
       return [];
@@ -1609,7 +1664,10 @@ class VersioningFileProvider extends FileSystemProvider {
       author: metadata.author ? String(metadata.author) : undefined,
       hasVersions: true,
       audienceRoles: Array.isArray(ar) && ar.length ? (ar as string[]) : undefined,
-      isPrivate: isPrivateFlag
+      isPrivate: isPrivateFlag,
+      addon: typeof (metadata as Record<string, unknown>).addon === 'string'
+        ? ((metadata as Record<string, unknown>).addon as string)
+        : undefined
     });
 
     logger.info(`[VersioningFileProvider] Saved page '${pageName}' with versioning`);


### PR DESCRIPTION
## Summary

Fixes the orphan-detector hole — checklist item 12 in [`docs/planning/addons.md`](../blob/master/docs/planning/addons.md), referenced from §2, §8 and §9.

`findOrphanedAddonPages` narrowed candidates with `searchByCategory('addon')`, which had two holes:

1. **Category-blind spot.** A seeded page declaring any other `system-category` was never a candidate — `addons/forms` ships one declaring `documentation`. The §9 re-categorisation decisions (feature UI → `system`, domain content → `general`, docs → `documentation`) would have widened this from one page to most of them.
2. **`no search ⇒ no detection`.** When SearchManager was unavailable the feature silently returned nothing, with no signal that detection had been skipped.

`addon` is stamped unconditionally by the seeder, so it is the reliable discriminator — but it was not indexed anywhere, so this adds it.

## Change

- `PageIndexEntry` gains optional **`addon`**, following the established optional-field pattern (`created?`, `author?`, `audienceRoles?`, `isPrivate?`) — **no schema migration required**
- `VersioningFileProvider` — populates it on save; adds `getAddonSeededIndexEntries()` and `setIndexAddon()`
- `PageManager` — delegates both, returning safe defaults for providers that maintain no index
- `AddonsManager` — reads candidates from the index, and **back-fills the stamp at boot** for pages seeded before the field existed
- detection no longer takes a `SearchManager` reference at all

The back-fill walks only each addon's own source pages — tens of files, not the 17k page tree. Verified live on jimstest: `Back-filled 'addon' index stamp on 8 seeded page(s)`.

## Tests

One existing case **asserted the defect** — *"returns [] when the search index is unavailable (best-effort, never guesses deletions)"* — and now asserts the opposite: detection works with no SearchManager at all.

Added: category-independence (an orphan whose `system-category` is `documentation`), `user-modified` passthrough, and ignoring index entries from addons that are not enabled.

Full suite **6721 passed**, `tsc` and lint clean.

## Known limitation — recorded rather than hidden

Detection is now only as complete as the page index. While verifying, jimstest turned out to carry **9 page files with no index entry** (and 17,817 entries against 17,796 files — drift in both directions). One of them is the `forms` page, so it stays undetectable.

That drift is **pre-existing** — this change only adds a field, it cannot remove entries — and is the same family as #954 (required pages seeded at install only, never verified afterwards). The index route is strictly better than the category route it replaces, but it is not total, and a page-index integrity pass would be the thing that closes the remainder.
