### PR TITLE
fix(deps): declare `globals` as a devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngdpbase",
-  "version": "3.68.1",
+  "version": "3.68.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngdpbase",
-      "version": "3.68.1",
+      "version": "3.68.2",
       "license": "ISC",
       "dependencies": {
         "@elastic/elasticsearch": "^8.19.1",
@@ -80,6 +80,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-formatter-summary": "^2.0.2",
         "eslint-plugin-prettier": "^5.5.4",
+        "globals": "^17.7.0",
         "jsdom": "^29.0.2",
         "lint-staged": "^16.2.7",
         "prettier": "^3.7.4",
@@ -1063,6 +1064,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
@@ -5977,9 +5991,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-formatter-summary": "^2.0.2",
     "eslint-plugin-prettier": "^5.5.4",
+    "globals": "^17.7.0",
     "jsdom": "^29.0.2",
     "lint-staged": "^16.2.7",
     "prettier": "^3.7.4",


### PR DESCRIPTION
## Summary

Declares `globals` as a devDependency. One line in `package.json`.

`eslint.config.mjs` has imported it since it was written:

```js
import globals from "globals";   // line 3
```

…but the package was never declared. It resolved only because ESLint 9 pulls it in transitively and npm hoists it to top-level `node_modules` — an undeclared import that has been working by luck.

## Why now

Found while evaluating **#961** (Dependabot's `eslint` 9 → 10 bump). ESLint 10 drops that transitive, so the config fails to load outright:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals'
  imported from /…/eslint.config.mjs
```

Fixing it here rather than inside #961, because declaring a package we import is correct **regardless** of which ESLint version we land on, and it should not be entangled with a major upgrade that still needs its own cleanup pass.

## Verification

- Lint output **unchanged** under ESLint 9: 5 warnings, 0 errors — same as master
- `npm ls globals --depth=0` now resolves it as a direct devDependency rather than a hoisted transitive
- Full suite **6721 passed**, build clean

## What this does *not* do

It does not unblock #961 on its own. With `globals` declared, ESLint 10 loads and then reports **72 errors** where master has 0:

| Rule | Count |
|---|---|
| `@typescript-eslint/no-unnecessary-type-assertion` | 72 |
| `no-unused-vars` | 3 |
| `explicit-function-return-type` | 2 |

`typescript-eslint` 8.65 sharpened `no-unnecessary-type-assertion`, and it now catches 72 redundant assertions across the codebase. `--fix` claims it can handle them, but 72 automated edits deserve their own PR and review rather than riding along on a dependency bump.

#961 stays open pending that cleanup.
