### PR TITLE
fix(parser): inline class token ends at first space; code spans opaque to style extraction (closes #944, #940)

### DIFF
--- a/src/parsers/MarkupParser.ts
+++ b/src/parsers/MarkupParser.ts
@@ -1512,6 +1512,29 @@ class MarkupParser extends BaseManager {
       sanitized = outputLines.join('\n');
     }
 
+    // #940/#944: mask `%` inside inline code spans before ANY style extraction.
+    //
+    // A style run must never close on a `/%` that belongs to a code span. On
+    // docs/haddock-styles this line:
+    //
+    //   you can use %%tip-predefinedStyles Use the `%~%style../%` markup.
+    //
+    // let the run swallow into the backticks and close on the `/%` *inside*
+    // them. That tore the code span apart; the orphaned backtick then paired
+    // with a later one, forming a <code> spanning lines, and every subsequent
+    // extraction landed in that broken context — 81 unrestored placeholders
+    // across the page, none of which reproduced when any single line was
+    // rendered alone.
+    //
+    // Masking rather than extracting: code spans cannot be pulled out here,
+    // because the block-style extractor below must still see raw backtick
+    // pairs (table-cell content is resolved by appendWikiNodes, which needs
+    // them intact). Substituting a same-length sentinel for `%` preserves
+    // every offset while making the span invisible to the style patterns.
+    // Restored immediately after block extraction, before backtick handling.
+    const CODE_PCT = ' ';
+    sanitized = sanitized.replace(/`[^`\n]*`/g, (span) => span.replace(/%/g, CODE_PCT));
+
     // #907: inline styles %%(css)…/%, %%sup…/%, %%sub…/%, %%strike…/% become
     // typed `inline-style` elements resolved to DOM nodes (no more Step 0.55
     // string passes). Innermost-first loop so nesting resolves bottom-up: the
@@ -1617,6 +1640,14 @@ class MarkupParser extends BaseManager {
     const styleResult = this.extractStyleBlocksWithStack(sanitized, jspwikiElements, uuid, id);
     sanitized = styleResult.content;
     id = styleResult.nextId;
+
+    // #940/#944: un-mask the `%` characters hidden inside code spans above.
+    // Both style extractors have run, so the sentinel has served its purpose
+    // and the literal text must be intact before backtick handling turns these
+    // spans into <code>.
+    if (sanitized.includes(CODE_PCT)) {
+      sanitized = sanitized.split(CODE_PCT).join('%');
+    }
 
     // Inline code spans — CommonMark variable-length backtick delimiters
     // (#753). A run of N backticks opens; a run of *exactly* N backticks

--- a/src/parsers/MarkupParser.ts
+++ b/src/parsers/MarkupParser.ts
@@ -1537,7 +1537,7 @@ class MarkupParser extends BaseManager {
       // exclude `%%class ` too — otherwise `%%a %%b X/%` reads the second `%%`
       // as A's closer and emits an empty `<span class="a">` followed by the
       // rest as stray text.
-      const NOT_AN_OPENER = String.raw`(?!\(|sup|sub|strike|[A-Za-z][\w-]*[ \t])`;
+      const NOT_AN_OPENER = String.raw`(?!\(|sup|sub|strike|[A-Za-z][\w-]*(?:\.[A-Za-z][\w-]*)*[ \t])`;
       const inlinePattern = new RegExp(
         String.raw`%%(\((?:[^()]|\([^()]*\))*\)|sup|sub|strike)[ \t]+((?:(?!%%|\/%)[\s\S])*?)[ \t]*(?:\/%|%%${NOT_AN_OPENER})`
       );
@@ -1550,8 +1550,19 @@ class MarkupParser extends BaseManager {
       // line, so confining the match to one line makes that impossible.
       // No conflict the other way either: the block opener regex is anchored
       // `^\s*%%…$`, so a same-line run was never a block-opener candidate.
+      // #944: the class token runs up to the FIRST space — everything after it
+      // is content. Multiple classes are DOT-separated (`%%btn.btn-info.btn-xs`),
+      // matching JSPWiki and what docs/haddock-styles documents.
+      //
+      // The original #939 form accepted space-separated classes inline
+      // (`[A-Za-z][\w-]*(?:[ \t]+[A-Za-z][\w-]*)*`) and silently ate the
+      // content: `%%lead Hello there/%` produced `class="lead Hello"` with only
+      // "there" as the body, and `%%lead one two three four/%` swallowed three
+      // words. Inline, space-separation is inherently ambiguous — nothing marks
+      // where the class list ends and the content begins. Block form keeps
+      // spaces because there the class list IS the whole line.
       const inlineClassPattern = new RegExp(
-        String.raw`%%([A-Za-z][\w-]*(?:[ \t]+[A-Za-z][\w-]*)*)[ \t]+((?:(?!%%|\/%)[^\n])*?)[ \t]*(?:\/%|%%${NOT_AN_OPENER})`
+        String.raw`%%([A-Za-z][\w-]*(?:\.[A-Za-z][\w-]*)*)[ \t]+((?:(?!%%|\/%)[^\n])*?)[ \t]*(?:\/%|%%${NOT_AN_OPENER})`
       );
       let guard = 0;
       for (;;) {
@@ -1586,7 +1597,8 @@ class MarkupParser extends BaseManager {
           syntax: m[0],
           inlineVariant: variant,
           cssRaw: isCss ? head.slice(1, -1) : undefined,
-          classNames: isClass ? head.replace(/[ \t]+/g, ' ') : undefined,
+          // #944: `btn.btn-info.btn-xs` -> `class="btn btn-info btn-xs"`.
+          classNames: isClass ? head.replace(/\./g, ' ') : undefined,
           inner,
           id: id++,
           position: m.index

--- a/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
+++ b/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
@@ -261,3 +261,45 @@ describe('MarkupParser inline class styles (#938)', () => {
     });
   });
 });
+
+describe('code spans are opaque to style extraction (#940/#944)', () => {
+  let p: MarkupParser;
+  beforeEach(async () => { p = new MarkupParser(new MockEngine() as never); await p.initialize(); });
+  afterEach(async () => { await p.shutdown(); });
+
+  test('a run does NOT close on a /% that lives inside a code span', async () => {
+    // The haddock-styles reproducer. Before the fix the run swallowed into the
+    // backticks and closed on the inner `/%`, tearing the span apart; the
+    // orphaned backtick then paired with a later one and every downstream
+    // extraction leaked an unrestored placeholder.
+    const result = await p.parse('you can use %%tip Use the `%~%style../%` markup.');
+    expect(result).not.toContain('data-jspwiki-placeholder');
+    expect(result).toContain('<code>');
+  });
+
+  test('two such lines together produce no leaked placeholders', async () => {
+    // Minimal cross-line reproducer — neither line leaked in isolation.
+    const result = await p.parse(
+      'you can use %%tip-a Use the `%~%style../%` markup. \\\n' +
+      'And even add or %%tip-b overwriting .header , .footer, etc. /% styles with `%~%add-css`.'
+    );
+    expect(result).not.toContain('data-jspwiki-placeholder');
+  });
+
+  test('a complete style run inside backticks stays literal', async () => {
+    const result = await p.parse('x `%%strike Some text here /%` y');
+    expect(result).not.toContain('data-jspwiki-placeholder');
+    expect(result).toContain('%%strike Some text here /%');
+  });
+
+  test('percent signs inside code spans survive verbatim', async () => {
+    const result = await p.parse('`100% of %% and /%` done');
+    expect(result).toContain('100% of %% and /%');
+  });
+
+  test('a real style OUTSIDE backticks still renders alongside one inside', async () => {
+    const result = await p.parse('`%%lead nope/%` and %%lead yes please/%');
+    expect(result).toContain('<span class="lead">yes please</span>');
+    expect(result).toContain('%%lead nope/%');
+  });
+});

--- a/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
+++ b/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
@@ -70,8 +70,8 @@ describe('MarkupParser inline class styles (#938)', () => {
     expect(result).toContain('<span class="feed-badge">GREEN</span>');
   });
 
-  test('multiple space-separated classes land on one span', async () => {
-    const result = await parser.parse('%%feed-badge feed-badge--green GREEN/%');
+  test('multiple DOT-separated classes land on one span', async () => {
+    const result = await parser.parse('%%feed-badge.feed-badge--green GREEN/%');
     expect(result).toContain('<span class="feed-badge feed-badge--green">GREEN</span>');
   });
 
@@ -95,7 +95,7 @@ describe('MarkupParser inline class styles (#938)', () => {
 
   test('multi-class span renders inside a table cell', async () => {
     const result = await parser.parse(
-      '|| Level || Code ||\n| NORMAL | %%feed-badge feed-badge--green GREEN/% |'
+      '|| Level || Code ||\n| NORMAL | %%feed-badge.feed-badge--green GREEN/% |'
     );
     expect(result).toContain('<span class="feed-badge feed-badge--green">GREEN</span>');
   });
@@ -104,9 +104,9 @@ describe('MarkupParser inline class styles (#938)', () => {
     const result = await parser.parse([
       '%%table-fit table-bordered table-striped table-hover sortable',
       '|| Level || Aviation Code || Meaning ||',
-      '| NORMAL | %%feed-badge feed-badge--green GREEN/% | typical background |',
-      '| ADVISORY | %%feed-badge feed-badge--yellow YELLOW/% | elevated unrest |',
-      '| WARNING | %%feed-badge feed-badge--red RED/% | eruption imminent |',
+      '| NORMAL | %%feed-badge.feed-badge--green GREEN/% | typical background |',
+      '| ADVISORY | %%feed-badge.feed-badge--yellow YELLOW/% | elevated unrest |',
+      '| WARNING | %%feed-badge.feed-badge--red RED/% | eruption imminent |',
       '/%'
     ].join('\n'));
     expect(result).toContain('<span class="feed-badge feed-badge--green">GREEN</span>');
@@ -208,5 +208,56 @@ describe('MarkupParser inline class styles (#938)', () => {
     // part of the emitted class list.
     const result = await parser.parse('%%feed-badge onload=x GREEN/%');
     expect(result).not.toMatch(/<span[^>]*onload/);
+  });
+  // ── #944: content must survive intact ─────────────────────────────────────
+  //
+  // The #939 form accepted space-separated classes inline and greedily ate the
+  // content: `%%lead Hello there/%` produced class="lead Hello" with only
+  // "there" as the body. Every fixture in the original suite used SINGLE-WORD
+  // content, so nothing caught it. These use multi-word content deliberately.
+
+  describe('multi-word content (#944 regression)', () => {
+    test('two-word content stays in the body', async () => {
+      const result = await parser.parse('%%lead Hello there/%');
+      expect(result).toContain('<span class="lead">Hello there</span>');
+    });
+
+    test('four-word content stays in the body', async () => {
+      const result = await parser.parse('%%lead one two three four/%');
+      expect(result).toContain('<span class="lead">one two three four</span>');
+    });
+
+    test('content containing words that look like class names is not absorbed', async () => {
+      const result = await parser.parse('%%small this small text/%');
+      expect(result).toContain('<span class="small">this small text</span>');
+    });
+
+    test('punctuated sentence content survives', async () => {
+      const result = await parser.parse('%%tip Use the markup, then reload./%');
+      expect(result).toContain('<span class="tip">Use the markup, then reload.</span>');
+    });
+
+    test('dotted multi-class with multi-word content', async () => {
+      const result = await parser.parse('%%btn.btn-info.btn-xs Click me now/%');
+      expect(result).toContain('<span class="btn btn-info btn-xs">Click me now</span>');
+    });
+
+    test('space-separated classes are NO LONGER treated as classes inline', async () => {
+      // Deliberate behaviour change: only the first token is the class.
+      const result = await parser.parse('%%feed-badge feed-badge--green GREEN/%');
+      expect(result).toContain('<span class="feed-badge">feed-badge--green GREEN</span>');
+    });
+
+    test('block form still takes space-separated classes', async () => {
+      // Unambiguous there — the class list is the whole line.
+      const result = await parser.parse('%%table-fit table-bordered\n|| A ||\n| 1 |\n/%');
+      expect(result).toContain('table-fit');
+      expect(result).toContain('table-bordered');
+    });
+
+    test('empty content still yields a bare classed span (icon idiom)', async () => {
+      const result = await parser.parse('%%icon-user /%');
+      expect(result).toContain('<span class="icon-user"></span>');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes two distinct parser bugs. Together they restore `docs/haddock-styles`, which rendered with **81 unrestored placeholders**.

Closes #944. Closes #940.

## Bug 1 — inline class runs ate their own content (regression from #939)

| Source | Rendered | Should be |
|---|---|---|
| `%%lead Hello there/%` | `class="lead Hello"`, body `there` | `class="lead"`, body `Hello there` |
| `%%lead one two three four/%` | `class="lead one two three"`, body `four` | class `lead`, full body |
| `%%btn.btn-info.btn-xs Button/%` | rendered literally | `class="btn btn-info btn-xs"` |

Space-separated classes are unambiguous in **block** form — the class list is the whole line — but ambiguous **inline**, where nothing marks where classes stop and content starts. JSPWiki uses dots, as the damaged page itself documents: *"You can use the `.` operator to combine multiple styles"*. #939 accepted the space form and rejected the dotted one, exactly backwards.

**New rule:** the class token ends at the first space; everything after is content. Multi-class is dot-separated.

**Behaviour change:** `%%feed-badge feed-badge--green GREEN/%` now yields `class="feed-badge"` with `feed-badge--green GREEN` as content. The dotted form is the replacement. Two places need updating — the geohazardwatch alert-levels table and the temp-build demo page. Block form is untouched.

Every fixture in the original #939 suite used **single-word content**, which is why none of them caught this.

## Bug 2 — code spans were not opaque to style extraction (#940, pre-existing)

A style run could close on a `/%` living **inside** a backtick code span:

```text
you can use %%tip-predefinedStyles Use the `%~%style../%` markup.
                                            └─ run closed here ─┘
```

That tore the code span apart. The orphaned backtick paired with a later one, forming a `<code>` spanning lines, and every subsequent extraction landed in that broken context — cascading to 81 leaked placeholders.

**This was invisible line-by-line.** Rendering *any* single line of the page produced zero leaks; the trigger is one line's run reaching into the next line's structure. It reproduced only with two specific lines together, which is why the first several bisection attempts found nothing.

### Why masking, not extracting

Code spans cannot simply be extracted before style handling: the block-style extractor below must still see **raw backtick pairs**, because table-cell content is resolved by `appendWikiNodes`, which needs them intact. Masking `%` with a same-length sentinel preserves every offset while making the span invisible to the style patterns, then restores immediately after block extraction. No ordering change, no index arithmetic.

## Verification

On the real page:

```text
leaks:          81 -> 0
<code> spans:   154 (intact)
classed spans:  68 (rendering)
```

```html
<code>%~%lead</code> -- <span class="lead">Larger lead text</span>
… normal font, like <span class="small">this small text</span>
```

Suite **6734 passed**, `tsc` and lint clean.

New tests include the **two-line cross-boundary reproducer** — the case no single-line test could have caught — plus multi-word content, punctuated sentences, dotted multi-class, percent signs surviving verbatim inside code spans, and a real style rendering alongside a literal one.
