### PR TITLE
fix(parser): un-mask the code-span sentinel in extracted elements too (#940)

### DIFF
--- a/src/parsers/MarkupParser.ts
+++ b/src/parsers/MarkupParser.ts
@@ -1532,7 +1532,10 @@ class MarkupParser extends BaseManager {
     // them intact). Substituting a same-length sentinel for `%` preserves
     // every offset while making the span invisible to the style patterns.
     // Restored immediately after block extraction, before backtick handling.
-    const CODE_PCT = ' ';
+    //
+    // Written as an escape, never as a literal NUL byte in this file: a raw NUL
+    // makes grep treat MarkupParser.ts as binary and silently suppress matches.
+    const CODE_PCT = '\u0000';
     sanitized = sanitized.replace(/`[^`\n]*`/g, (span) => span.replace(/%/g, CODE_PCT));
 
     // #907: inline styles %%(css)…/%, %%sup…/%, %%sub…/%, %%strike…/% become
@@ -1645,8 +1648,28 @@ class MarkupParser extends BaseManager {
     // Both style extractors have run, so the sentinel has served its purpose
     // and the literal text must be intact before backtick handling turns these
     // spans into <code>.
+    // The sweep must cover the extracted elements too, not just `sanitized`.
+    // Both extractors above MOVE text out of `sanitized` into ExtractedElement
+    // fields, so a masked `%` that was carried into an element's content would
+    // survive every later pass and reach the browser as a raw NUL byte. That is
+    // exactly what shipped in the first cut of this fix: the page rendered
+    // correctly (0 leaks, all code spans intact) while emitting 40 stray NULs.
+    // Un-masking is 1 char -> 1 char, so no recorded offset moves.
+    const unmask = (value: string): string => value.split(CODE_PCT).join('%');
     if (sanitized.includes(CODE_PCT)) {
-      sanitized = sanitized.split(CODE_PCT).join('%');
+      sanitized = unmask(sanitized);
+    }
+    for (const element of jspwikiElements) {
+      const fields = element as unknown as Record<string, unknown>;
+      for (const [key, value] of Object.entries(fields)) {
+        if (typeof value === 'string' && value.includes(CODE_PCT)) {
+          fields[key] = unmask(value);
+        } else if (Array.isArray(value)) {
+          fields[key] = (value as unknown[]).map((item) =>
+            typeof item === 'string' && item.includes(CODE_PCT) ? unmask(item) : item
+          );
+        }
+      }
     }
 
     // Inline code spans — CommonMark variable-length backtick delimiters

--- a/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
+++ b/src/parsers/__tests__/MarkupParser-InlineClassStyles.test.ts
@@ -302,4 +302,33 @@ describe('code spans are opaque to style extraction (#940/#944)', () => {
     expect(result).toContain('<span class="lead">yes please</span>');
     expect(result).toContain('%%lead nope/%');
   });
+
+  // The masking sentinel must never reach the output. The first cut of this fix
+  // un-masked only the working buffer, not the text the extractors had already
+  // MOVED into ExtractedElement fields, so the live page rendered perfectly —
+  // 0 leaks, every code span intact — while emitting 40 raw NUL bytes. Every
+  // existing assertion above passed, because a NUL is invisible to `toContain`.
+  const SENTINEL = '\u0000';
+
+  test.each([
+    ['single-line reproducer', 'you can use %%tip Use the `%~%style../%` markup.'],
+    ['cross-line reproducer',
+      'you can use %%tip-a Use the `%~%style../%` markup. \\\n' +
+      'And even add or %%tip-b overwriting .header , .footer, etc. /% styles with `%~%add-css`.'],
+    ['style run wholly inside backticks', 'x `%%strike Some text here /%` y'],
+    ['bare percents in a code span', '`100% of %% and /%` done'],
+    ['style inside and outside backticks', '`%%lead nope/%` and %%lead yes please/%'],
+    ['code span inside a table cell', '| a | `%%lead x/%` | %%lead y here/% |']
+  ])('emits no masking sentinel: %s', async (_name, input) => {
+    expect(await p.parse(input)).not.toContain(SENTINEL);
+  });
+
+  test('percent inside a code span carried into a style body is restored', async () => {
+    // The exact path that leaked: the `%` is masked, then the inline-style
+    // extractor moves the whole body into an element, so un-masking `sanitized`
+    // alone never touches it.
+    const result = await p.parse('%%lead see the `50%` rate/%');
+    expect(result).not.toContain(SENTINEL);
+    expect(result).toContain('50%');
+  });
 });


### PR DESCRIPTION
Follow-up to #965 / 8abd5056.

That fix made the page render correctly but shipped a defect I missed: **40 raw NUL bytes in the served HTML**.

```text
placeholders:  0     ok
code spans:    161   ok
classed spans: 68    ok
NUL bytes:     40    BAD
```

## Cause

Both style extractors **move** text out of `sanitized` into `ExtractedElement` fields. The restore pass swept only `sanitized`, so a masked `%` already carried into an element's content survived every later pass and reached the browser as a raw NUL.

Sweep the extracted elements too. Un-masking is 1 char to 1 char, so no recorded offset moves.

## Also

The sentinel was written as a **literal NUL byte** in the source. That made `grep` classify `MarkupParser.ts` as binary and silently return nothing -- output that reads as "not present" rather than "suppressed". Now the escape '\u0000'.

## Why the tests didn't catch it

A NUL is invisible to `toContain`. Every assertion in the suite passed on the broken output, including the ones written specifically for this fix.

Added a case asserting a `%` inside a code span nested in a style body survives -- it fails without this change -- plus sentinel-absence guards over the reproducers. (Only the first is decisive; the guards are cheap insurance.)

## Verified live

40 NUL bytes to 0, rendering otherwise unchanged. Suite **6741 passed**, `tsc` clean.
