### PR TITLE
feat(pages): soft-delete pages so a delete is recoverable in-app (#947)

### DIFF
--- a/config/app-default-config.json
+++ b/config/app-default-config.json
@@ -61,6 +61,8 @@
   "ngdpbase.page.provider.versioning.indexfile": "${FAST_STORAGE}/page-index.json",
   "ngdpbase.page.provider.filesystem.encoding": "utf-8",
   "ngdpbase.page.provider.filesystem.autosave": true,
+  "_comment_page_delete": "Days a soft-deleted page stays restorable before it is purged along with its version history (#947). Set 0 to keep deleted pages forever.",
+  "ngdpbase.page.delete.retentiondays": 30,
   "_comment_page_chrome": "Pages excluded from tab injection or footer rendering",
   "ngdpbase.page.notabs": [
     "LeftMenu",

--- a/src/managers/PageManager.ts
+++ b/src/managers/PageManager.ts
@@ -878,11 +878,13 @@ class PageManager extends BaseManager implements CatalogSource {
     }
 
     const identifier = wikiContext.pageName;
+    const deletedBy = wikiContext.userContext?.username || 'anonymous';
 
-    // Future: Could add audit logging here using wikiContext.userContext
-    logger.info(`[PageManager] Deleting page: ${identifier} by user: ${wikiContext.userContext?.username || 'anonymous'}`);
+    logger.info(`[PageManager] Deleting page: ${identifier} by user: ${deletedBy}`);
 
-    return this.provider.deletePage(identifier);
+    // #947: pass the acting user through so the tombstone records who deleted
+    // the page. Providers that predate soft delete ignore the extra argument.
+    return this.provider.deletePage(identifier, deletedBy);
   }
 
   /**

--- a/src/managers/__tests__/PageManager.test.ts
+++ b/src/managers/__tests__/PageManager.test.ts
@@ -464,7 +464,8 @@ describe('PageManager', () => {
 
       await pageManager.deletePageWithContext(wikiContext);
 
-      expect(pageManager.provider.deletePage).toHaveBeenCalledWith('Test Page');
+      // #947: the acting user is passed through so the tombstone records who deleted it
+      expect(pageManager.provider.deletePage).toHaveBeenCalledWith('Test Page', 'testuser');
     });
   });
 

--- a/src/providers/BasePageProvider.ts
+++ b/src/providers/BasePageProvider.ts
@@ -144,7 +144,7 @@ abstract class BasePageProvider {
    * @param {string} identifier - Page UUID or title
    * @returns {Promise<boolean>} True if deleted, false if not found
    */
-  abstract deletePage(identifier: string): Promise<boolean>;
+  abstract deletePage(identifier: string, deletedBy?: string): Promise<boolean>;
 
   /**
    * Move a private page from one creator's directory to another's.

--- a/src/providers/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider.ts
@@ -296,6 +296,11 @@ class FileSystemProvider extends BasePageProvider {
         if (entry.isDirectory()) {
           if (entry.name.startsWith('.')) continue; // Skip hidden dirs
           if (entry.name === 'versions') continue; // Skip version snapshot dirs
+          // #947: soft-deleted pages are relocated here. They MUST stay out of
+          // the scan — this walk is what rebuilds the caches on every boot, so
+          // a tombstoned file left in place would silently resurrect itself on
+          // the next restart, index flag or not.
+          if (entry.name === 'deleted') continue;
           out.push(...(await this.walkDir(full)));
         } else if (entry.isFile()) {
           out.push(full);
@@ -320,7 +325,7 @@ class FileSystemProvider extends BasePageProvider {
    * @returns {PageCacheInfo|null} Page info or null if not found
    * @private
    */
-  private resolvePageInfo(identifier: string): PageCacheInfo | null {
+  protected resolvePageInfo(identifier: string): PageCacheInfo | null {
     if (!identifier || typeof identifier !== 'string') return null;
 
     // 1. Try UUID index first
@@ -687,19 +692,7 @@ class FileSystemProvider extends BasePageProvider {
       await fs.unlink(info.filePath);
 
       // Remove from all caches and indexes
-      // Ensure title is string for cache operations (YAML may have parsed as number)
-      const titleStr = String(info.title);
-      this.pageCache.delete(titleStr);
-      this.contentCache.delete(titleStr);
-      this.titleIndex.delete(titleStr.toLowerCase());
-      if (info.uuid) {
-        this.uuidIndex.delete(info.uuid);
-      }
-      // Remove slug from index if it existed
-      const slug = info.metadata?.slug;
-      if (slug) {
-        this.slugIndex.delete(String(slug).toLowerCase());
-      }
+      this.evictFromCaches(info);
 
       logger.info(`[FileSystemProvider] Deleted page '${info.title}' (${info.uuid})`);
       return true;
@@ -712,6 +705,75 @@ class FileSystemProvider extends BasePageProvider {
       }
       return false;
     }
+  }
+
+  /**
+   * Drop a page from every in-memory cache and lookup index, leaving the file
+   * on disk untouched.
+   *
+   * Split out of {@link deletePage} for #947: the soft-delete path needs the
+   * exact same cache teardown (so the page disappears from view, listing,
+   * search and resolution) while relocating the file instead of unlinking it.
+   * Keeping one implementation means a future cache can't be added to delete
+   * and forgotten in soft-delete.
+   *
+   * @param info - Resolved page info for the page to evict
+   */
+  protected evictFromCaches(info: PageCacheInfo): void {
+    // Ensure title is string for cache operations (YAML may have parsed as number)
+    const titleStr = String(info.title);
+    this.pageCache.delete(titleStr);
+    this.contentCache.delete(titleStr);
+    this.titleIndex.delete(titleStr.toLowerCase());
+    if (info.uuid) {
+      this.uuidIndex.delete(info.uuid);
+    }
+    // Remove slug from index if it existed
+    const slug = info.metadata?.slug;
+    if (slug) {
+      this.slugIndex.delete(String(slug).toLowerCase());
+    }
+  }
+
+  /**
+   * Re-register a page in every in-memory cache and lookup index.
+   *
+   * The inverse of {@link evictFromCaches}, used by the #947 restore path so a
+   * recovered page is immediately resolvable without a provider reload.
+   *
+   * @param info - Resolved page info for the page to register
+   * @param content - Page body (frontmatter already stripped)
+   */
+  protected addToCaches(info: PageCacheInfo, content: string): void {
+    const titleStr = String(info.title);
+    this.pageCache.set(titleStr, info);
+    this.contentCache.set(titleStr, content);
+    this.titleIndex.set(titleStr.toLowerCase(), titleStr);
+    if (info.uuid) {
+      this.uuidIndex.set(info.uuid, titleStr);
+    }
+    const slug = info.metadata?.slug;
+    if (slug) {
+      this.slugIndex.set(String(slug).toLowerCase(), titleStr);
+    }
+  }
+
+  /**
+   * Whether a title or slug is currently claimed by a live page.
+   *
+   * Used by the #947 restore path: a tombstoned page keeps its title and slug
+   * only in the tombstone record, so nothing stops a NEW page from taking them
+   * while the old one sits in the trash. Restoring blind would put two pages on
+   * one title, so restore checks first and refuses.
+   *
+   * @param title - Title to test
+   * @param slug - Slug to test (optional)
+   * @returns The conflicting field, or null when both are free
+   */
+  protected findLiveNameConflict(title: string, slug?: string): 'title' | 'slug' | null {
+    if (this.titleIndex.has(String(title).toLowerCase())) return 'title';
+    if (slug && this.slugIndex.has(String(slug).toLowerCase())) return 'slug';
+    return null;
   }
 
   /**

--- a/src/providers/VersioningFileProvider.ts
+++ b/src/providers/VersioningFileProvider.ts
@@ -71,11 +71,35 @@ interface PageIndexEntry {
 /**
  * Page index structure
  */
+/**
+ * A soft-deleted page (#947).
+ *
+ * Deliberately stored in its OWN map rather than as a `deleted: true` flag on
+ * the live `pages` record. Better than twenty-odd call sites in this file
+ * iterating `pageIndex.pages` to list, count, search and report — every one of
+ * them would need a filter, and the first one anybody forgot would leak a
+ * deleted page back into a listing. A separate map makes the exclusion
+ * structural: existing consumers cannot see tombstones at all.
+ */
+interface DeletedPageEntry extends PageIndexEntry {
+  /** When the page was deleted (ISO 8601) */
+  deletedAt: string;
+  /** Username that deleted it, or 'unknown' when the caller supplied no context */
+  deletedBy: string;
+  /** Absolute path the page file occupied before deletion — where restore puts it back */
+  deletedFrom: string;
+}
+
 interface PageIndex {
   version: string;
   lastUpdated: string;
   pageCount: number;
   pages: Record<string, PageIndexEntry>;
+  /**
+   * Soft-deleted pages awaiting restore or purge (#947). Optional because
+   * indexes written before this feature have no such key.
+   */
+  deletedPages?: Record<string, DeletedPageEntry>;
 }
 
 
@@ -192,6 +216,9 @@ class VersioningFileProvider extends FileSystemProvider {
   private versionCache: Map<string, string>;
   private versionCacheSize: number;
 
+  /** Days a soft-deleted page stays recoverable before purge; 0 = keep forever (#947) */
+  private deleteRetentionDays: number;
+
   /**
    * Create a new VersioningFileProvider
    * @param engine - The WikiEngine instance
@@ -221,6 +248,7 @@ class VersioningFileProvider extends FileSystemProvider {
     // Version cache for performance (LRU cache)
     this.versionCache = new Map();
     this.versionCacheSize = 50;
+    this.deleteRetentionDays = 30;
   }
 
   /**
@@ -270,10 +298,24 @@ class VersioningFileProvider extends FileSystemProvider {
       await this.loadOrCreatePageIndex();
     }
 
+    // #947: expire tombstones past the retention window. Runs at boot rather
+    // than on a timer because there is no central maintenance scheduler yet —
+    // a long-running server therefore only purges when it restarts. Acceptable
+    // while the failure mode is "deleted pages are recoverable for longer than
+    // configured"; a scheduled sweep belongs with the trash UI follow-up.
+    try {
+      await this.purgeExpiredDeletedPages();
+    } catch (error) {
+      // Never let purge failure block startup — the pages are still on disk.
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error('[VersioningFileProvider] Delete-retention purge failed at startup', { error: errorMessage });
+    }
+
     logger.info('[VersioningFileProvider] Initialized with versioning enabled');
     logger.info(`[VersioningFileProvider] Delta storage: ${this.deltaStorageEnabled ? 'enabled' : 'disabled'}`);
     logger.info(`[VersioningFileProvider] Compression: ${this.compressionEnabled ? 'enabled' : 'disabled'}`);
     logger.info(`[VersioningFileProvider] Max versions: ${this.maxVersions}, Retention: ${this.retentionDays} days`);
+    logger.info(`[VersioningFileProvider] Deleted-page retention: ${this.deleteRetentionDays > 0 ? `${this.deleteRetentionDays} days` : 'kept forever'}`);
   }
 
   /**
@@ -601,6 +643,13 @@ class VersioningFileProvider extends FileSystemProvider {
     this.retentionDays = configManager.getProperty(
       'ngdpbase.page.provider.versioning.retentiondays',
       365
+    ) as number;
+
+    // #947: how long a soft-deleted page stays recoverable before purge.
+    // 0 means keep tombstones forever.
+    this.deleteRetentionDays = configManager.getProperty(
+      'ngdpbase.page.delete.retentiondays',
+      30
     ) as number;
 
     // Storage optimization settings
@@ -1389,24 +1438,6 @@ class VersioningFileProvider extends FileSystemProvider {
   }
 
   /**
-   * Remove a page from the page index
-   * @param uuid - Page UUID
-   */
-  private removePageFromIndex(uuid: string): Promise<void> {
-    if (!this.pageIndex) {
-      throw new Error('Page index not initialized');
-    }
-
-    if (this.pageIndex.pages[uuid]) {
-      delete this.pageIndex.pages[uuid];
-      this.pageIndex.pageCount--;
-      logger.info(`[VersioningFileProvider] Removed page ${uuid} from index`);
-      return this.savePageIndex();
-    }
-    return Promise.resolve();
-  }
-
-  /**
    * Rename a UUID in the page index (used by adopt-UUID operations that move a file to a new UUID).
    * Updates the index entry key and uuid field, then persists the index.
    * No-op if oldUuid is not in the index.
@@ -1732,11 +1763,31 @@ class VersioningFileProvider extends FileSystemProvider {
   }
 
   /**
-   * Delete a page and its version history
+   * Soft-delete a page (#947).
+   *
+   * Before this change a delete was the one destructive content action with no
+   * undo: the page file, every stored version AND the index entry were removed
+   * outright, so `POST /api/page/:identifier/restore/:version` had nothing left
+   * to restore from and no way to resolve the identifier. Recovery depended
+   * entirely on whatever backup retention a deployment happened to have.
+   *
+   * Now the page file is MOVED into a `deleted/` directory beside its storage
+   * root, the version directory is left completely untouched, and the index
+   * entry moves from `pages` to `deletedPages` with the metadata restore needs.
+   *
+   * The file has to move rather than stay put: the boot scan
+   * (`FileSystemProvider.walkDir`) rebuilds the caches from disk, so a file
+   * left in `pages/` would be re-indexed on the next restart and the page would
+   * silently come back to life. `walkDir` skips `deleted/` for that reason.
+   *
+   * Purging for real happens in {@link purgeExpiredDeletedPages} once the
+   * retention window expires.
+   *
    * @param identifier - Page UUID or title
+   * @param deletedBy - Username performing the delete (audit trail)
    * @returns True if deleted, false if not found
    */
-  async deletePage(identifier: string): Promise<boolean> {
+  async deletePage(identifier: string, deletedBy = 'unknown'): Promise<boolean> {
     // Get page info before deleting
     const pageData = await this.getPage(identifier);
     if (!pageData) {
@@ -1751,30 +1802,210 @@ class VersioningFileProvider extends FileSystemProvider {
       (pageData.metadata?.['system-category']?.toLowerCase() === 'system' ? 'required-pages' : 'pages');
 
     try {
-      // Call parent to delete main file and clear caches
-      const deleted = await super.deletePage(identifier);
-      if (!deleted) {
+      const info = this.resolvePageInfo(identifier);
+      if (!info) {
+        logger.warn(`[VersioningFileProvider] Cannot delete - unresolvable: ${identifier}`);
         return false;
       }
 
-      // Delete version directory if it exists
-      const versionDir = this.getVersionDirectory(uuid, location);
-      const versionDirExists = await fs.pathExists(versionDir);
-      if (versionDirExists) {
-        await fs.remove(versionDir);
-        logger.info(`[VersioningFileProvider] Deleted version directory for ${uuid}`);
+      const sourcePath = info.filePath;
+      const trashDir = this.getDeletedDirectory(location);
+      const trashPath = path.join(trashDir, `${uuid}.md`);
+
+      await fs.ensureDir(trashDir);
+      await fs.move(sourcePath, trashPath, { overwrite: true });
+
+      // Same cache teardown the hard delete used to do — the page must vanish
+      // from view, listing, search and identifier resolution immediately.
+      this.evictFromCaches(info);
+
+      // Move the index entry into the tombstone map. The version directory is
+      // deliberately NOT touched: it is the whole point of the exercise.
+      const existing = this.pageIndex?.pages[uuid];
+      if (this.pageIndex && existing) {
+        this.pageIndex.deletedPages ??= {};
+        this.pageIndex.deletedPages[uuid] = {
+          ...existing,
+          deletedAt: new Date().toISOString(),
+          deletedBy,
+          deletedFrom: sourcePath
+        };
+        delete this.pageIndex.pages[uuid];
+        this.pageIndex.pageCount = Object.keys(this.pageIndex.pages).length;
+        await this.savePageIndex();
       }
 
-      // Remove from page index
-      await this.removePageFromIndex(uuid);
-
-      logger.info(`[VersioningFileProvider] Deleted page '${identifier}' with all versions`);
+      logger.info(
+        `[VersioningFileProvider] Soft-deleted page '${identifier}' (${uuid}) by ${deletedBy}; ` +
+        'versions retained for restore'
+      );
       return true;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error(`[VersioningFileProvider] Failed to delete page: ${identifier}`, { error: errorMessage });
       return false;
     }
+  }
+
+  /**
+   * Directory holding soft-deleted page files for a storage location (#947).
+   *
+   * Private pages land in the same `pages/deleted/` directory as public ones
+   * rather than keeping their `private/{creator}/` nesting — the tombstone
+   * records the original path in `deletedFrom`, so restore puts the file back
+   * exactly where it came from without the trash layout having to mirror the
+   * live one.
+   */
+  private getDeletedDirectory(location: 'pages' | 'required-pages' | 'private'): string {
+    const base = location === 'required-pages'
+      ? this.requiredPagesDirectory
+      : this.pagesDirectory;
+
+    if (!base) {
+      throw new Error('Storage directories not initialized');
+    }
+
+    return path.join(base, 'deleted');
+  }
+
+  /**
+   * List soft-deleted pages, newest deletion first (#947).
+   *
+   * @returns Tombstone records awaiting restore or purge
+   */
+  getDeletedPages(): DeletedPageEntry[] {
+    const deleted = this.pageIndex?.deletedPages;
+    if (!deleted) return [];
+    // Tie-break on title: two pages deleted in the same millisecond are common
+    // (a script, or a user clearing several pages) and an unstable sort makes
+    // the trash listing jump around between requests for no visible reason.
+    return Object.values(deleted).sort((a, b) => {
+      const delta = new Date(b.deletedAt).getTime() - new Date(a.deletedAt).getTime();
+      return delta !== 0 ? delta : String(a.title).localeCompare(String(b.title));
+    });
+  }
+
+  /**
+   * Restore a soft-deleted page, with its full version history (#947).
+   *
+   * Refuses when the page's title or slug has been claimed by a live page since
+   * the delete. Restoring anyway would put two pages on one title and corrupt
+   * the lookup indexes, and picking a new name silently is worse — the caller
+   * gets a clear conflict and decides.
+   *
+   * @param uuid - UUID of the deleted page
+   * @returns Result describing success, or why the restore was refused
+   */
+  async restoreDeletedPage(uuid: string): Promise<{ ok: true; title: string } | { ok: false; reason: 'not-found' | 'title-conflict' | 'slug-conflict' | 'file-missing' | 'error'; detail?: string }> {
+    const entry = this.pageIndex?.deletedPages?.[uuid];
+    if (!entry || !this.pageIndex) {
+      return { ok: false, reason: 'not-found' };
+    }
+
+    const conflict = this.findLiveNameConflict(entry.title, entry.slug);
+    if (conflict) {
+      logger.warn(
+        `[VersioningFileProvider] Cannot restore ${uuid}: ${conflict} '${conflict === 'title' ? entry.title : entry.slug}' is in use by a live page`
+      );
+      return {
+        ok: false,
+        reason: conflict === 'title' ? 'title-conflict' : 'slug-conflict',
+        detail: conflict === 'title' ? entry.title : entry.slug
+      };
+    }
+
+    const trashPath = path.join(this.getDeletedDirectory(entry.location), `${uuid}.md`);
+    if (!(await fs.pathExists(trashPath))) {
+      logger.error(`[VersioningFileProvider] Tombstone for ${uuid} has no file at ${trashPath}`);
+      return { ok: false, reason: 'file-missing', detail: trashPath };
+    }
+
+    try {
+      await fs.ensureDir(path.dirname(entry.deletedFrom));
+      await fs.move(trashPath, entry.deletedFrom, { overwrite: false });
+
+      // Re-register in the live caches so the page resolves immediately,
+      // without waiting for a provider reload.
+      const raw = await fs.readFile(entry.deletedFrom, this.encoding);
+      const parsed = matter(raw);
+      this.addToCaches(
+        {
+          title: entry.title,
+          uuid,
+          filePath: entry.deletedFrom,
+          metadata: parsed.data as PageFrontmatter
+        },
+        parsed.content
+      );
+
+      const { deletedAt: _deletedAt, deletedBy: _deletedBy, deletedFrom: _deletedFrom, ...live } = entry;
+      this.pageIndex.pages[uuid] = live;
+      delete this.pageIndex.deletedPages?.[uuid];
+      this.pageIndex.pageCount = Object.keys(this.pageIndex.pages).length;
+      await this.savePageIndex();
+
+      logger.info(`[VersioningFileProvider] Restored page '${entry.title}' (${uuid}) with version history`);
+      return { ok: true, title: entry.title };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logger.error(`[VersioningFileProvider] Failed to restore ${uuid}`, { error: detail });
+      return { ok: false, reason: 'error', detail };
+    }
+  }
+
+  /**
+   * Permanently destroy a soft-deleted page: file, versions and tombstone (#947).
+   *
+   * This is the only path that still does what the old `deletePage` did. It is
+   * never reached by a normal delete — only by an explicit purge or by
+   * retention expiry.
+   *
+   * @param uuid - UUID of the deleted page
+   * @returns True when something was purged
+   */
+  async purgeDeletedPage(uuid: string): Promise<boolean> {
+    const entry = this.pageIndex?.deletedPages?.[uuid];
+    if (!entry || !this.pageIndex) return false;
+
+    try {
+      const trashPath = path.join(this.getDeletedDirectory(entry.location), `${uuid}.md`);
+      await fs.remove(trashPath);
+      await fs.remove(this.getVersionDirectory(uuid, entry.location));
+      delete this.pageIndex.deletedPages?.[uuid];
+      await this.savePageIndex();
+      logger.info(`[VersioningFileProvider] Purged deleted page '${entry.title}' (${uuid}) and its versions`);
+      return true;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(`[VersioningFileProvider] Failed to purge ${uuid}`, { error: errorMessage });
+      return false;
+    }
+  }
+
+  /**
+   * Purge soft-deleted pages past the retention window (#947).
+   *
+   * A retention of 0 disables purging entirely — tombstones are kept until an
+   * admin removes them explicitly.
+   *
+   * @returns Number of pages purged
+   */
+  async purgeExpiredDeletedPages(): Promise<number> {
+    if (!this.deleteRetentionDays || this.deleteRetentionDays <= 0) return 0;
+
+    const cutoff = Date.now() - this.deleteRetentionDays * 24 * 60 * 60 * 1000;
+    let purged = 0;
+
+    for (const entry of this.getDeletedPages()) {
+      if (new Date(entry.deletedAt).getTime() < cutoff) {
+        if (await this.purgeDeletedPage(entry.uuid)) purged++;
+      }
+    }
+
+    if (purged > 0) {
+      logger.info(`[VersioningFileProvider] Purged ${purged} page(s) past the ${this.deleteRetentionDays}-day delete retention`);
+    }
+    return purged;
   }
 
   /**

--- a/src/providers/VersioningFileProvider.ts
+++ b/src/providers/VersioningFileProvider.ts
@@ -219,6 +219,9 @@ class VersioningFileProvider extends FileSystemProvider {
   /** Days a soft-deleted page stays recoverable before purge; 0 = keep forever (#947) */
   private deleteRetentionDays: number;
 
+  /** Hourly tick that expires tombstones past the retention window (#947) */
+  private deletePurgeTimer: ReturnType<typeof setInterval> | null;
+
   /**
    * Create a new VersioningFileProvider
    * @param engine - The WikiEngine instance
@@ -249,6 +252,7 @@ class VersioningFileProvider extends FileSystemProvider {
     this.versionCache = new Map();
     this.versionCacheSize = 50;
     this.deleteRetentionDays = 30;
+    this.deletePurgeTimer = null;
   }
 
   /**
@@ -298,18 +302,11 @@ class VersioningFileProvider extends FileSystemProvider {
       await this.loadOrCreatePageIndex();
     }
 
-    // #947: expire tombstones past the retention window. Runs at boot rather
-    // than on a timer because there is no central maintenance scheduler yet —
-    // a long-running server therefore only purges when it restarts. Acceptable
-    // while the failure mode is "deleted pages are recoverable for longer than
-    // configured"; a scheduled sweep belongs with the trash UI follow-up.
-    try {
-      await this.purgeExpiredDeletedPages();
-    } catch (error) {
-      // Never let purge failure block startup — the pages are still on disk.
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.error('[VersioningFileProvider] Delete-retention purge failed at startup', { error: errorMessage });
-    }
+    // #947: expire tombstones past the retention window — once at boot, then
+    // on an hourly tick so a long-running server does not sit on expired
+    // tombstones until someone restarts it.
+    await this.runRetentionPurge('startup');
+    this.startDeletePurgeScheduler();
 
     logger.info('[VersioningFileProvider] Initialized with versioning enabled');
     logger.info(`[VersioningFileProvider] Delta storage: ${this.deltaStorageEnabled ? 'enabled' : 'disabled'}`);
@@ -1845,6 +1842,69 @@ class VersioningFileProvider extends FileSystemProvider {
       logger.error(`[VersioningFileProvider] Failed to delete page: ${identifier}`, { error: errorMessage });
       return false;
     }
+  }
+
+  /**
+   * Run the retention purge, swallowing any failure (#947).
+   *
+   * Purge is housekeeping: it must never take down startup or kill the
+   * scheduler tick. Nothing is lost when it fails — the tombstones are still
+   * on disk and the next run will pick them up.
+   *
+   * @param trigger - Where the run came from, for the log line
+   */
+  private async runRetentionPurge(trigger: 'startup' | 'scheduled'): Promise<void> {
+    try {
+      await this.purgeExpiredDeletedPages();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(`[VersioningFileProvider] Delete-retention purge failed (${trigger})`, { error: errorMessage });
+    }
+  }
+
+  /**
+   * Start the hourly tombstone-expiry tick (#947).
+   *
+   * Follows the scheduler shape BackupManager already uses: a plain
+   * `setInterval` with `unref()` so it never holds the process open. Hourly
+   * rather than BackupManager's per-minute tick because the work is
+   * time-window based, not time-of-day based — there is no specific minute it
+   * has to catch, and a page expiring up to an hour late is meaningless
+   * against a retention measured in days.
+   *
+   * Skipped entirely when retention is disabled, so a `0` config leaves no
+   * timer running at all.
+   */
+  private startDeletePurgeScheduler(): void {
+    this.stopDeletePurgeScheduler();
+
+    if (!this.deleteRetentionDays || this.deleteRetentionDays <= 0) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      void this.runRetentionPurge('scheduled');
+    }, 60 * 60 * 1000);
+
+    timer.unref(); // don't prevent process exit
+    this.deletePurgeTimer = timer;
+    logger.info(`[VersioningFileProvider] Delete-retention purge scheduled hourly (${this.deleteRetentionDays}-day window)`);
+  }
+
+  /** Stop the tombstone-expiry tick (#947). */
+  private stopDeletePurgeScheduler(): void {
+    if (this.deletePurgeTimer) {
+      clearInterval(this.deletePurgeTimer);
+      this.deletePurgeTimer = null;
+    }
+  }
+
+  /**
+   * Shut down the provider, stopping the retention scheduler (#947).
+   */
+  shutdown(): void {
+    this.stopDeletePurgeScheduler();
+    super.shutdown();
   }
 
   /**

--- a/src/providers/__tests__/VersioningFileProvider-SoftDelete.test.ts
+++ b/src/providers/__tests__/VersioningFileProvider-SoftDelete.test.ts
@@ -270,6 +270,57 @@ describe('VersioningFileProvider - soft delete (#947)', () => {
     expect(provider['pageIndex'].deletedPages[freshUuid]).toBeDefined();
   });
 
+  test('an hourly scheduler expires tombstones without needing a restart', async () => {
+    vi.useFakeTimers();
+    try {
+      const { uuid, title } = await seedPage();
+      await provider.deletePage(title, 'jim');
+
+      // Backdate past the 30-day window, then let the hourly tick fire.
+      provider['pageIndex'].deletedPages[uuid].deletedAt =
+        new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      vi.useRealTimers();
+
+      // The tick fires synchronously but the purge itself does real fs work,
+      // which fake timers do not gate — wait for it to settle rather than
+      // asserting into a race.
+      for (let i = 0; i < 100 && provider['pageIndex'].deletedPages[uuid]; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      expect(provider['pageIndex'].deletedPages[uuid]).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('the scheduler tick does not hold the process open', async () => {
+    await provider.initialize();
+    // unref'd like BackupManager's scheduler — otherwise the server can't exit.
+    expect(provider['deletePurgeTimer']).not.toBeNull();
+    expect(typeof provider['deletePurgeTimer'].unref).toBe('function');
+  });
+
+  test('shutdown stops the retention scheduler', async () => {
+    await provider.initialize();
+    expect(provider['deletePurgeTimer']).not.toBeNull();
+
+    provider.shutdown();
+
+    expect(provider['deletePurgeTimer']).toBeNull();
+  });
+
+  test('retention of 0 starts no scheduler at all', async () => {
+    await provider.initialize();
+    provider.shutdown();
+    provider['deleteRetentionDays'] = 0;
+    provider['startDeletePurgeScheduler']();
+
+    expect(provider['deletePurgeTimer']).toBeNull();
+  });
+
   test('retention of 0 keeps tombstones forever', async () => {
     const { uuid, title } = await seedPage();
     await provider.deletePage(title, 'jim');

--- a/src/providers/__tests__/VersioningFileProvider-SoftDelete.test.ts
+++ b/src/providers/__tests__/VersioningFileProvider-SoftDelete.test.ts
@@ -1,0 +1,282 @@
+/**
+ * @file VersioningFileProvider-SoftDelete.test.ts
+ * @description #947 — deleting a page must be recoverable in-app.
+ *
+ * Before #947 a delete removed the page file, the entire version directory AND
+ * the index entry, so nothing in the app could find or restore it. These tests
+ * pin the replacement contract: the versions survive, the page disappears from
+ * every live lookup, and restore brings both back.
+ */
+
+// Opt out of the global VersioningFileProvider and FileSystemProvider mocks
+vi.unmock('../VersioningFileProvider');
+vi.unmock('../../providers/VersioningFileProvider');
+vi.unmock('../FileSystemProvider');
+vi.unmock('../../providers/FileSystemProvider');
+
+import VersioningFileProvider from '../VersioningFileProvider';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import DeltaStorage from '../../utils/DeltaStorage';
+
+describe('VersioningFileProvider - soft delete (#947)', () => {
+  let testDir;
+  let engine;
+  let configManager;
+  let provider;
+
+  beforeEach(async () => {
+    // Create temporary directory for tests
+    testDir = path.join(os.tmpdir(), `versioning-provider-test-${Date.now()}`);
+    await fs.ensureDir(testDir);
+
+    const indexPath = path.join(testDir, 'data', 'page-index.json');
+
+    // Create mock engine and ConfigurationManager
+    configManager = {
+      getProperty: vi.fn((key, defaultValue) => {
+        const config = {
+          'ngdpbase.page.enabled': true,
+          'ngdpbase.page.provider.filesystem.storagedir': path.join(testDir, 'pages'),
+          'ngdpbase.page.provider.filesystem.requiredpagesdir': path.join(testDir, 'required-pages'),
+          'ngdpbase.page.provider.filesystem.encoding': 'utf-8',
+          'ngdpbase.page.provider.filesystem.autosave': true,
+          'ngdpbase.page.provider.filesystem.pluralmatching': false,
+          'ngdpbase.page.provider.versioning.indexfile': indexPath,
+          'ngdpbase.page.provider.versioning.maxversions': 50,
+          'ngdpbase.page.provider.versioning.retentiondays': 365,
+          'ngdpbase.page.provider.versioning.compression': 'gzip',
+          'ngdpbase.page.provider.versioning.deltastorage': true,
+          'ngdpbase.page.provider.versioning.checkpointinterval': 10,
+          'ngdpbase.page.provider.versioning.cachesize': 50
+        };
+        return config[key] !== undefined ? config[key] : defaultValue;
+      }),
+      getResolvedDataPath: vi.fn((key, defaultValue) => {
+        if (key === 'ngdpbase.page.provider.versioning.indexfile') {
+          return path.join(testDir, 'data', 'page-index.json');
+        }
+        if (key === 'ngdpbase.page.provider.filesystem.storagedir') {
+          return path.join(testDir, 'pages');
+        }
+        if (key === 'ngdpbase.page.provider.filesystem.requiredpagesdir') {
+          return path.join(testDir, 'required-pages');
+        }
+        return defaultValue;
+      }),
+      getInstanceDataFolder: vi.fn(() => testDir)
+    };
+
+    engine = {
+      getManager: vi.fn((managerName) => {
+        if (managerName === 'ConfigurationManager') {
+          return configManager;
+        }
+        return null;
+      })
+    };
+
+    // Create provider instance
+    provider = new VersioningFileProvider(engine);
+  });
+
+  afterEach(async () => {
+    // Only ever removes this test's own temp directory under os.tmpdir().
+    if (await fs.pathExists(testDir)) {
+      await fs.remove(testDir);
+    }
+  });
+
+  const seedPage = async (title = 'Doomed Page') => {
+    await provider.initialize();
+    await provider.savePage(title, 'v1 content', { author: 'jim' });
+    await provider.savePage(title, 'v2 content', { author: 'jim' });
+    await provider.savePage(title, 'v3 content', { author: 'jim' });
+    const page = await provider.getPage(title);
+    return { uuid: page.uuid, title };
+  };
+
+  test('version history SURVIVES a delete (the #947 regression)', async () => {
+    const { uuid, title } = await seedPage();
+    const versionDir = provider._getVersionDirectory(uuid, 'pages');
+
+    expect(await provider.getVersionHistory(title)).toHaveLength(3);
+
+    await provider.deletePage(title, 'jim');
+
+    // The old implementation did fs.remove(versionDir) right here.
+    expect(await fs.pathExists(versionDir)).toBe(true);
+    expect((await fs.readdir(versionDir)).sort()).toEqual(['manifest.json', 'v1', 'v2', 'v3']);
+  });
+
+  test('the deleted page is invisible to every live lookup', async () => {
+    const { uuid, title } = await seedPage();
+    await provider.deletePage(title, 'jim');
+
+    expect(await provider.getPage(title)).toBeNull();
+    expect(await provider.getPage(uuid)).toBeNull();
+    expect(provider.pageExists(title)).toBe(false);
+    expect(provider['pageIndex'].pages[uuid]).toBeUndefined();
+  });
+
+  test('the page file is MOVED, not deleted, and out of the boot scan path', async () => {
+    const { uuid, title } = await seedPage();
+    const originalPath = path.join(testDir, 'pages', `${uuid}.md`);
+    expect(await fs.pathExists(originalPath)).toBe(true);
+
+    await provider.deletePage(title, 'jim');
+
+    expect(await fs.pathExists(originalPath)).toBe(false);
+    expect(await fs.pathExists(path.join(testDir, 'pages', 'deleted', `${uuid}.md`))).toBe(true);
+  });
+
+  test('a tombstoned page does NOT come back after a provider reload', async () => {
+    // The reason the file has to move: initialize() rebuilds caches from disk.
+    const { uuid, title } = await seedPage();
+    await provider.deletePage(title, 'jim');
+
+    const reloaded = new VersioningFileProvider(engine);
+    await reloaded.initialize();
+
+    expect(await reloaded.getPage(title)).toBeNull();
+    expect(reloaded['pageIndex'].pages[uuid]).toBeUndefined();
+    expect(reloaded['pageIndex'].deletedPages[uuid]).toBeDefined();
+  });
+
+  test('the tombstone records who deleted it and when', async () => {
+    const { uuid, title } = await seedPage();
+    const before = Date.now();
+    await provider.deletePage(title, 'alice');
+
+    const tomb = provider['pageIndex'].deletedPages[uuid];
+    expect(tomb.deletedBy).toBe('alice');
+    expect(tomb.title).toBe(title);
+    expect(new Date(tomb.deletedAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+    expect(tomb.deletedFrom).toContain(`${uuid}.md`);
+  });
+
+  test('deletedBy defaults to unknown when no user is supplied', async () => {
+    const { uuid, title } = await seedPage();
+    await provider.deletePage(title);
+    expect(provider['pageIndex'].deletedPages[uuid].deletedBy).toBe('unknown');
+  });
+
+  test('getDeletedPages lists tombstones newest first', async () => {
+    await provider.initialize();
+    await provider.savePage('First', 'a', { author: 'jim' });
+    await provider.savePage('Second', 'b', { author: 'jim' });
+    const firstUuid = (await provider.getPage('First')).uuid;
+    await provider.deletePage('First', 'jim');
+    await provider.deletePage('Second', 'jim');
+
+    // Backdate explicitly. Both deletes land in the same millisecond often
+    // enough that asserting on wall-clock order alone is a flake — it passed
+    // in isolation and failed in the full suite.
+    provider['pageIndex'].deletedPages[firstUuid].deletedAt =
+      new Date(Date.now() - 60_000).toISOString();
+
+    expect(provider.getDeletedPages().map((e) => e.title)).toEqual(['Second', 'First']);
+  });
+
+  test('same-millisecond deletions sort deterministically by title', async () => {
+    await provider.initialize();
+    await provider.savePage('Bravo', 'a', { author: 'jim' });
+    await provider.savePage('Alpha', 'b', { author: 'jim' });
+    await provider.deletePage('Bravo', 'jim');
+    await provider.deletePage('Alpha', 'jim');
+
+    const stamp = new Date().toISOString();
+    for (const entry of Object.values(provider['pageIndex'].deletedPages)) {
+      entry.deletedAt = stamp;
+    }
+
+    expect(provider.getDeletedPages().map((e) => e.title)).toEqual(['Alpha', 'Bravo']);
+  });
+
+  test('restore brings back the page AND its history', async () => {
+    const { uuid, title } = await seedPage();
+    await provider.deletePage(title, 'jim');
+
+    const result = await provider.restoreDeletedPage(uuid);
+    expect(result).toEqual({ ok: true, title });
+
+    const page = await provider.getPage(title);
+    expect(page).not.toBeNull();
+    expect(page.content).toContain('v3 content');
+    expect(await provider.getVersionHistory(title)).toHaveLength(3);
+    expect(provider['pageIndex'].pages[uuid]).toBeDefined();
+    expect(provider['pageIndex'].deletedPages[uuid]).toBeUndefined();
+  });
+
+  test('a restored page is resolvable by uuid without a reload', async () => {
+    const { uuid, title } = await seedPage();
+    await provider.deletePage(title, 'jim');
+    await provider.restoreDeletedPage(uuid);
+
+    expect(await provider.getPage(uuid)).not.toBeNull();
+    expect(provider.pageExists(title)).toBe(true);
+  });
+
+  test('restore refuses when the title was reclaimed by a live page', async () => {
+    // The edge that makes silent restore dangerous: nothing stops a new page
+    // taking the title while the old one sits in the trash.
+    const { uuid, title } = await seedPage();
+    await provider.deletePage(title, 'jim');
+    await provider.savePage(title, 'a different page now', { author: 'bob' });
+
+    const result = await provider.restoreDeletedPage(uuid);
+    expect(result).toEqual({ ok: false, reason: 'title-conflict', detail: title });
+
+    // And it changed nothing.
+    expect(provider['pageIndex'].deletedPages[uuid]).toBeDefined();
+    expect((await provider.getPage(title)).content).toContain('a different page now');
+  });
+
+  test('restore reports not-found for an unknown uuid', async () => {
+    await provider.initialize();
+    expect(await provider.restoreDeletedPage('no-such-uuid')).toEqual({ ok: false, reason: 'not-found' });
+  });
+
+  test('purge is the ONLY path that destroys versions', async () => {
+    const { uuid, title } = await seedPage();
+    const versionDir = provider._getVersionDirectory(uuid, 'pages');
+    await provider.deletePage(title, 'jim');
+
+    expect(await provider.purgeDeletedPage(uuid)).toBe(true);
+
+    expect(await fs.pathExists(versionDir)).toBe(false);
+    expect(await fs.pathExists(path.join(testDir, 'pages', 'deleted', `${uuid}.md`))).toBe(false);
+    expect(provider['pageIndex'].deletedPages[uuid]).toBeUndefined();
+    expect(await provider.restoreDeletedPage(uuid)).toEqual({ ok: false, reason: 'not-found' });
+  });
+
+  test('retention purge removes tombstones past the window and keeps fresh ones', async () => {
+    await provider.initialize();
+    await provider.savePage('Old', 'a', { author: 'jim' });
+    await provider.savePage('Fresh', 'b', { author: 'jim' });
+    const oldUuid = (await provider.getPage('Old')).uuid;
+    const freshUuid = (await provider.getPage('Fresh')).uuid;
+
+    await provider.deletePage('Old', 'jim');
+    await provider.deletePage('Fresh', 'jim');
+
+    // Backdate one tombstone past the 30-day default.
+    provider['pageIndex'].deletedPages[oldUuid].deletedAt =
+      new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+
+    expect(await provider.purgeExpiredDeletedPages()).toBe(1);
+    expect(provider['pageIndex'].deletedPages[oldUuid]).toBeUndefined();
+    expect(provider['pageIndex'].deletedPages[freshUuid]).toBeDefined();
+  });
+
+  test('retention of 0 keeps tombstones forever', async () => {
+    const { uuid, title } = await seedPage();
+    await provider.deletePage(title, 'jim');
+    provider['deleteRetentionDays'] = 0;
+    provider['pageIndex'].deletedPages[uuid].deletedAt = new Date(0).toISOString();
+
+    expect(await provider.purgeExpiredDeletedPages()).toBe(0);
+    expect(provider['pageIndex'].deletedPages[uuid]).toBeDefined();
+  });
+});

--- a/src/providers/__tests__/VersioningFileProvider-WriteQueue.test.ts
+++ b/src/providers/__tests__/VersioningFileProvider-WriteQueue.test.ts
@@ -187,27 +187,12 @@ describe('VersioningFileProvider - Write Queue', () => {
     expect(written.pageCount).toBe(1);
   });
 
-  test('removePageFromIndex triggers serialized save', async () => {
-    // First add a page
-    provider['pageIndex'].pages['to-remove'] = {
-      title: 'Remove Me',
-      uuid: 'to-remove',
-      currentVersion: 1,
-      location: 'pages',
-      lastModified: new Date().toISOString(),
-      editor: 'test',
-      hasVersions: true
-    };
-    provider['pageIndex'].pageCount = 1;
-    await provider['savePageIndex']();
-
-    // Now remove it
-    await provider['removePageFromIndex']('to-remove');
-
-    const written = await fs.readJson(indexPath);
-    expect(written.pages['to-remove']).toBeUndefined();
-    expect(written.pageCount).toBe(0);
-  });
+  // The former `removePageFromIndex triggers serialized save` test was removed
+  // with #947: that method no longer exists, because a delete now MOVES the
+  // index entry into `deletedPages` rather than dropping it. The replacement
+  // coverage lives in VersioningFileProvider.test.ts, which runs a real
+  // initialize() — this harness hand-wires only the fields savePageIndex needs,
+  // so it cannot exercise a full delete.
 
   test('savePageIndex throws if page index not initialized', async () => {
     provider['pageIndex'] = null;

--- a/src/routes/WikiRoutes.ts
+++ b/src/routes/WikiRoutes.ts
@@ -151,7 +151,27 @@ interface IConfigManager {
   getBaseURL?(): string;
 }
 
+/**
+ * Soft-delete surface a page provider may expose (#947). All optional — a
+ * provider without these simply has no trash, and the routes answer 501.
+ */
+interface IDeletedPageEntry {
+  uuid: string;
+  title: string;
+  slug?: string;
+  currentVersion: number;
+  deletedAt: string;
+  deletedBy: string;
+}
+
+type RestoreResult =
+  | { ok: true; title: string }
+  | { ok: false; reason: 'not-found' | 'title-conflict' | 'slug-conflict' | 'file-missing' | 'error'; detail?: string };
+
 interface IVersioningProvider {
+  getDeletedPages?(): IDeletedPageEntry[];
+  restoreDeletedPage?(uuid: string): Promise<RestoreResult>;
+  purgeDeletedPage?(uuid: string): Promise<boolean>;
   getVersionHistory?(name: string, limit?: number): Promise<IVersionEntry[]>;
   compareVersions?(name: string, v1: number, v2: number): Promise<IComparisonResult | null>;
   restoreVersion?(name: string, version: number, options?: { author?: string; comment?: string }): Promise<number>;
@@ -11427,6 +11447,17 @@ ${panes}
       this.restorePageVersion(req, res)
     );
 
+    // #947 trash API — admin-only, enforced inside each handler
+    app.get('/api/admin/deleted-pages', (req: Request, res: Response) =>
+      this.listDeletedPages(req, res)
+    );
+    app.post('/api/admin/deleted-pages/:uuid/restore', (req: Request, res: Response) =>
+      this.restoreDeletedPage(req, res)
+    );
+    app.delete('/api/admin/deleted-pages/:uuid', (req: Request, res: Response) =>
+      this.purgeDeletedPage(req, res)
+    );
+
     // Public routes
     app.get('/', (req: Request, res: Response) => this.homePage(req, res));
     app.get('/view/:page', (req: Request, res: Response) => this.viewPage(req, res));
@@ -12907,6 +12938,140 @@ ${panes}
         error: 'Internal server error',
         details: getErrorMessage(error)
       });
+    }
+  }
+
+  /**
+   * Guard for the #947 trash endpoints: admin-only, JSON responses.
+   *
+   * Deleted pages are visible across every author and every audience, so
+   * listing or restoring them is strictly `admin-system`. It deliberately does
+   * NOT fall back to the per-page delete ACL — being allowed to delete your own
+   * page does not imply being allowed to browse everything anyone else deleted.
+   *
+   * @returns The provider when the caller is authorised, otherwise null (the
+   *          response has already been sent)
+   */
+  private async requireTrashAdmin(req: Request, res: Response): Promise<IVersioningProvider | null> {
+    if (!req.userContext?.isAuthenticated) {
+      res.status(401).json({ error: 'Authentication required' });
+      return null;
+    }
+
+    const userManager = this.engine.getManager('UserManager');
+    const isAdmin = await userManager?.hasPermission(req.userContext.username, 'admin-system');
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Access denied', message: 'Administrator access required' });
+      return null;
+    }
+
+    const provider = this.engine.getManager('PageManager')?.provider as IVersioningProvider | undefined;
+    if (!provider || typeof provider.getDeletedPages !== 'function') {
+      res.status(501).json({
+        error: 'Soft delete not supported',
+        message: 'Current page provider does not retain deleted pages'
+      });
+      return null;
+    }
+
+    return provider;
+  }
+
+  /**
+   * GET /api/admin/deleted-pages
+   * List soft-deleted pages awaiting restore or purge (#947).
+   */
+  async listDeletedPages(req: Request, res: Response) {
+    try {
+      const provider = await this.requireTrashAdmin(req, res);
+      if (!provider) return;
+
+      const pages = provider.getDeletedPages!().map((entry) => ({
+        uuid: entry.uuid,
+        title: entry.title,
+        slug: entry.slug,
+        deletedAt: entry.deletedAt,
+        deletedBy: entry.deletedBy,
+        currentVersion: entry.currentVersion
+      }));
+
+      return res.json({ success: true, count: pages.length, pages });
+    } catch (error: unknown) {
+      logger.error(`Error listing deleted pages: ${getErrorMessage(error)}`);
+      return res.status(500).json({ error: 'Internal server error', details: getErrorMessage(error) });
+    }
+  }
+
+  /**
+   * POST /api/admin/deleted-pages/:uuid/restore
+   * Restore a soft-deleted page, with its version history (#947).
+   */
+  async restoreDeletedPage(req: Request, res: Response) {
+    try {
+      const provider = await this.requireTrashAdmin(req, res);
+      if (!provider) return;
+
+      const { uuid } = req.params;
+      const result = await provider.restoreDeletedPage!(uuid);
+
+      if (!result.ok) {
+        // A name collision is the caller's to resolve, not ours to paper over:
+        // 409 with the offending value rather than a silent rename.
+        const status = result.reason === 'not-found' ? 404
+          : result.reason === 'title-conflict' || result.reason === 'slug-conflict' ? 409
+            : 500;
+        return res.status(status).json({
+          success: false,
+          error: result.reason,
+          detail: result.detail
+        });
+      }
+
+      // Bring the derived indexes back in step with the restored page. Delete
+      // pulled it out of the search index and the link graph; without this the
+      // page is readable but unfindable until the next full rebuild.
+      const pageManager = this.engine.getManager('PageManager');
+      const restored = await pageManager?.getPage(result.title);
+      if (restored) {
+        await this.engine.getManager('SearchManager')?.updatePageInIndex(result.title, {
+          name: result.title,
+          content: restored.content,
+          metadata: restored.metadata
+        });
+        this.engine.getManager('RenderingManager')?.updatePageInLinkGraph?.(result.title, restored.content);
+      }
+
+      logger.info(`[WikiRoutes] User ${req.userContext!.username} restored deleted page ${uuid} ('${result.title}')`);
+      return res.json({ success: true, uuid, title: result.title });
+    } catch (error: unknown) {
+      logger.error(`Error restoring deleted page: ${getErrorMessage(error)}`);
+      return res.status(500).json({ error: 'Internal server error', details: getErrorMessage(error) });
+    }
+  }
+
+  /**
+   * DELETE /api/admin/deleted-pages/:uuid
+   * Permanently destroy a soft-deleted page and its versions (#947).
+   *
+   * The only irreversible page operation left in the app.
+   */
+  async purgeDeletedPage(req: Request, res: Response) {
+    try {
+      const provider = await this.requireTrashAdmin(req, res);
+      if (!provider) return;
+
+      const { uuid } = req.params;
+      const purged = await provider.purgeDeletedPage!(uuid);
+
+      if (!purged) {
+        return res.status(404).json({ success: false, error: 'not-found' });
+      }
+
+      logger.warn(`[WikiRoutes] User ${req.userContext!.username} PERMANENTLY purged page ${uuid}`);
+      return res.json({ success: true, uuid });
+    } catch (error: unknown) {
+      logger.error(`Error purging deleted page: ${getErrorMessage(error)}`);
+      return res.status(500).json({ error: 'Internal server error', details: getErrorMessage(error) });
     }
   }
 

--- a/src/types/Provider.ts
+++ b/src/types/Provider.ts
@@ -169,9 +169,12 @@ export interface PageProvider extends BaseProvider {
   /**
    * Delete a page
    * @param identifier - Page UUID or title
+   * @param deletedBy - Username performing the delete; recorded on the tombstone
+   *                    by providers that support soft delete (#947). Optional so
+   *                    providers written before soft delete stay compatible.
    * @returns True if deleted, false if not found
    */
-  deletePage(identifier: string): Promise<boolean>;
+  deletePage(identifier: string, deletedBy?: string): Promise<boolean>;
 
   /**
    * Move a private page from one creator's directory to another's.

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,5 +1,5 @@
 import { test as setup, expect } from '@playwright/test';
-import { waitForServerReady } from './fixtures/helpers';
+import { waitForServerReady, TEST_PAGE_PREFIX } from './fixtures/helpers';
 
 const STORAGE_STATE = './tests/e2e/.auth/user.json';
 
@@ -40,4 +40,49 @@ setup('authenticate', async ({ page }) => {
 
   // Save authentication state
   await page.context().storageState({ path: STORAGE_STATE });
+
+  // #947: sweep away soft-deleted test pages left by earlier runs.
+  //
+  // deletePage() purges each page it deletes, so a current run cleans up after
+  // itself. This catches the back-catalogue: runs from before that landed, and
+  // any run where the purge step failed. Without it those tombstones and their
+  // version directories sit in storage for the whole retention window — the
+  // same slow accumulation as #724, one level down where nobody looks.
+  //
+  // Scoped strictly to the NGDPBASE-test prefix. It must never purge anything
+  // else: the suite runs against real instances, and a blanket trash-empty
+  // would destroy genuinely deleted pages an operator was still holding.
+  await purgeStaleTestPages(page);
 });
+
+/**
+ * Purge soft-deleted pages matching the E2E test prefix (#947).
+ *
+ * Best-effort: a provider without soft delete answers 501, and a failure here
+ * is storage hygiene, not correctness — it must never block the suite.
+ *
+ * @param {import('@playwright/test').Page} page - Authenticated page
+ */
+async function purgeStaleTestPages(page) {
+  try {
+    const listRes = await page.request.get('/api/admin/deleted-pages');
+    if (listRes.status() !== 200) return;
+
+    const body = await listRes.json();
+    const stale = (body.pages || []).filter((p) => String(p.title).startsWith(TEST_PAGE_PREFIX));
+    if (stale.length === 0) return;
+
+    const tokenRes = await page.request.get('/login');
+    const match = (await tokenRes.text()).match(/<meta name="csrf-token" content="([^"]+)"/);
+    if (!match) return;
+
+    for (const entry of stale) {
+      await page.request.delete(`/api/admin/deleted-pages/${encodeURIComponent(entry.uuid)}`, {
+        headers: { Accept: 'application/json', 'X-CSRF-Token': match[1] }
+      });
+    }
+    console.log(`[auth.setup] Purged ${stale.length} stale ${TEST_PAGE_PREFIX}-* tombstone(s)`);
+  } catch {
+    // Never fail the suite over cleanup of prior runs.
+  }
+}

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -66,6 +66,47 @@ async function deletePage(page, pageName) {
         `(delete status ${status}, /view status ${verify.status()})`
     );
   }
+
+  // #947: a delete is now a soft delete — the page file and its full version
+  // history are retained for the retention window (30 days by default). That
+  // is right for real content and wrong for test fixtures: without this step
+  // every E2E run would leave tombstones and version directories behind for a
+  // month, which is #724's "187 stale NGDPBASE-test-* pages" all over again,
+  // just one level down where nobody would look for it.
+  //
+  // Purge only what THIS helper just deleted, matched by exact title. Never a
+  // blanket "purge everything in the trash" — that would destroy real deleted
+  // pages on whatever instance the suite happens to run against.
+  await purgeDeletedPage(page, pageName, csrfToken);
+}
+
+/**
+ * Permanently remove a soft-deleted test page and its versions (#947).
+ *
+ * Best-effort by design: the page is already gone from every user-visible
+ * surface by the time this runs, so a purge failure is a storage-hygiene
+ * problem, not a correctness one, and must not fail an otherwise-passing test.
+ * A provider without soft delete answers 501 and this is a no-op.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} pageName - Exact title of the page just deleted
+ * @param {string} csrfToken - Token already obtained by the caller
+ */
+async function purgeDeletedPage(page, pageName, csrfToken) {
+  try {
+    const listRes = await page.request.get('/api/admin/deleted-pages');
+    if (listRes.status() !== 200) return;
+
+    const body = await listRes.json();
+    const match = (body.pages || []).find((p) => p.title === pageName);
+    if (!match) return;
+
+    await page.request.delete(`/api/admin/deleted-pages/${encodeURIComponent(match.uuid)}`, {
+      headers: { Accept: 'application/json', 'X-CSRF-Token': csrfToken }
+    });
+  } catch {
+    // Storage hygiene only — never break a test run over it.
+  }
 }
 
 /**
@@ -197,6 +238,7 @@ export {
   waitForPageReady,
   createPage,
   deletePage,
+  purgeDeletedPage,
   deletePages,
   navigateToPage,
   performSearch,


### PR DESCRIPTION
Closes #947.

## The problem

Deleting a page removed the page file, the **entire version directory**, and the index entry. `POST /api/page/:identifier/restore/:version` couldn't help — the versions were gone, and so was the index entry it resolves identifiers through.

Confirmed against the real provider before changing anything — a page with 3 versions, then delete:

```text
versionsBefore:        3
dirContentsBefore:     [manifest.json, v1, v2, v3]
versionDirExistsAfter: false
pageAfter:             null
inIndexAfter:          false
```

Recovery depended entirely on backup retention. On this instance that's one backup, dated 2026-03-11 — four months stale. So the delete was unrecoverable in practice, not just in theory.

## The change

A delete now moves the page file to `<location>/deleted/`, leaves the version directory **untouched**, and moves the index entry into a `deletedPages` map with `deletedAt` / `deletedBy` / `deletedFrom`.

Two design points, because the obvious implementations are both wrong:

**The file has to move, not stay put.** `FileSystemProvider.walkDir` rebuilds the caches from disk on every boot. A tombstoned file left in `pages/` gets re-indexed on the next restart and the page silently comes back to life — index flag or no index flag. `walkDir` now skips `deleted/`, and a test asserts the page stays gone across a full provider reload.

**Tombstones get their own map, not a `deleted: true` flag.** Twenty-odd call sites iterate `pageIndex.pages` to list, count, search and report. Flagging would need a filter in every one, and the first one anybody forgot would leak a deleted page back into a listing. A separate map makes the exclusion structural instead of a discipline problem.

## Restore conflicts

Restore refuses when the title or slug was reclaimed by a live page since the delete — **409** with the offending value, rather than silently overwriting or silently renaming. That collision is genuinely reachable: nothing stops a new page taking the name while the old one sits in the trash.

## API

Admin-only (`admin-system`) — deliberately **not** the per-page delete ACL. Being allowed to delete your own page shouldn't let you browse everything everyone else deleted.

```text
GET    /api/admin/deleted-pages
POST   /api/admin/deleted-pages/:uuid/restore
DELETE /api/admin/deleted-pages/:uuid
```

Verified live: `GET` returns 401 anonymous; the mutating routes are caught by CSRF first, so the layering is right.

## Retention

New key `ngdpbase.page.delete.retentiondays`, default **30**, `0` = keep forever. Purge is now the only path that destroys a version history.

Purge runs at boot and then hourly — see the scheduler note below.

## Also fixed

`getDeletedPages` sorted on timestamp alone, so pages deleted in the same millisecond ordered unstably — it passed in isolation and failed in the full suite. Tie-broken on title.

## Not in this slice

The admin trash **UI** (option 3 in the issue). Storage semantics first.

## Verification

15 new tests, including the reload case and the title-reclaim conflict.

On jimstest across a restart: **17798** page files, **17821** version directories, **17817** index entries — all untouched, 0 purged.

Suite **6755 unit + 80 E2E** green, `tsc` and lint clean.


---

## Update: hourly scheduler (was restart-only)

The first cut ran the purge only at startup, on my claim that the codebase had no scheduler to hook into. That was wrong — `BackupManager` has run a scheduled job all along: a `setInterval` tick with `unref()`, started from `initialize()` and cleared on stop.

Now follows the same shape. Hourly rather than BackupManager's per-minute tick, because this is time-*window* based rather than time-of-day based — there's no specific minute to catch, and a tombstone expiring up to an hour late is meaningless against a retention measured in days.

- `unref()`'d, so it never holds the process open
- retention `0` starts no timer at all
- `shutdown()` clears it
- purge failures are logged and swallowed — housekeeping must not kill the tick

Live on jimstest:

```text
[VersioningFileProvider] Delete-retention purge scheduled hourly (30-day window)
```

4 new tests; 3 of them confirmed to fail when the `startDeletePurgeScheduler()` call is removed.

## Update: E2E cleanup (found by running it)

Soft delete quietly broke E2E cleanup. `deletePage()` still verified the page was gone from `/view` — and it was — but the file and its version history now sat in the trash for 30 days. One run left **11 tombstones and 11 retained version directories** on jimstest, and every run after would have added more.

That's #724 again (187 stale `NGDPBASE-test-*` pages found in live storage on 2026-05-16), one level down where nobody would look.

Two parts, both scoped strictly to the test prefix and both best-effort:

- `deletePage()` purges the page it just deleted, matched by exact title — a run cleans up after itself
- `auth.setup` sweeps leftover `NGDPBASE-test-*` tombstones, catching the back-catalogue and any run whose purge step failed

Deliberately **not** a blanket trash-empty: the suite runs against real instances, and that would destroy genuinely deleted pages an operator was still holding.

Verified:

```text
[auth.setup] Purged 11 stale NGDPBASE-test-* tombstone(s)

tombstones:        11 -> 0
version dirs:   17832 -> 17821
live index:     17817 (unchanged)
```

A follow-up run left zero new tombstones. **80 E2E + 6759 unit** green.
