### PR TITLE
feat(api): DELETE and rename page endpoints for agent tokens (#946 slice 2)

### DIFF
--- a/src/routes/WikiRoutes.ts
+++ b/src/routes/WikiRoutes.ts
@@ -361,6 +361,26 @@ export const contactRateLimiter = new SimpleRateLimiter({ max: 5, windowMs: 15 *
  */
 export const shareRateLimiter = new SimpleRateLimiter({ max: 600, windowMs: 10 * 60 * 1000 });
 
+/**
+ * Rate limiter for token-authenticated page mutations (#946 slice 2), keyed by
+ * token id so one runaway agent cannot starve another.
+ *
+ * Deferred in slice 1 on the grounds that ingest is an idempotent upsert — a
+ * repeated create/edit converges. Delete and rename are neither idempotent nor
+ * self-correcting, and a token runs unattended for up to 24 hours, so a loop
+ * has real consequences.
+ *
+ * #947 softened the worst case considerably: a delete is now recoverable for
+ * the retention window rather than destroying version history outright. That
+ * lowers the severity but does not remove the need — a delete loop still churns
+ * every page it touches into the trash, and rename has no such safety net at
+ * all.
+ *
+ * 60/minute is far above any legitimate agent editing rate and far below what
+ * a runaway loop would produce.
+ */
+export const agentMutationRateLimiter = new SimpleRateLimiter({ max: 60, windowMs: 60 * 1000 });
+
 const imageStorage: StorageEngine = multer.diskStorage({
   destination: (_req: Request, _file: Express.Multer.File, cb: (error: Error | null, destination: string) => void) => {
     const uploadDir = path.join(__dirname, '../../public/images');
@@ -3843,6 +3863,274 @@ ${panes}
   /**
    * Delete a page
    */
+  /**
+   * Guard shared by the #946 slice-2 mutation endpoints.
+   *
+   * Applies the token rate limit before anything else, then resolves the page
+   * and checks the caller's permission for `action`. Returns null once a
+   * response has been sent.
+   */
+  private async prepareApiPageMutation(
+    req: Request,
+    res: Response,
+    action: 'delete' | 'rename'
+  ): Promise<{ pageData: WikiPage; wikiContext: WikiContext; pageName: string } | null> {
+    const identifier = req.params.identifier;
+
+    if (!req.userContext?.isAuthenticated) {
+      res.status(401).json({ error: 'Authentication required' });
+      return null;
+    }
+
+    // Rate limit token-authenticated mutations only. A human clicking Delete is
+    // bounded by being a human; an unattended token is not.
+    const viaToken = (req.userContext as { viaToken?: { id?: string } }).viaToken;
+    if (viaToken?.id) {
+      const verdict = agentMutationRateLimiter.consume(viaToken.id);
+      if (!verdict.allowed) {
+        res.set('Retry-After', String(Math.ceil(verdict.retryAfterMs / 1000)));
+        res.status(429).json({
+          error: 'Rate limit exceeded',
+          message: `Too many page mutations for this token. Retry in ${Math.ceil(verdict.retryAfterMs / 1000)}s.`
+        });
+        return null;
+      }
+    }
+
+    const pageManager = this.engine.getManager('PageManager');
+    const pageData = await pageManager?.getPage(identifier);
+    if (!pageData) {
+      res.status(404).json({ error: 'Page not found', identifier });
+      return null;
+    }
+
+    // Resolve to the canonical title: the identifier may be a uuid or slug, and
+    // every downstream index is keyed by title.
+    const pageName = (pageData.metadata?.title) || identifier;
+
+    const wikiContext = this.createWikiContext(req, {
+      context: WikiContext.CONTEXT.NONE,
+      pageName,
+      response: res
+    });
+    (wikiContext as { pageMetadata: unknown }).pageMetadata = pageData.metadata ?? null;
+    (wikiContext as { content: string | null }).content = pageData.content;
+
+    // Required pages stay admin-only, matching the form route.
+    if (await this.isRequiredPage(pageName)) {
+      const userManager = this.engine.getManager('UserManager');
+      const isAdmin = await userManager?.hasPermission(req.userContext.username, 'admin-system');
+      if (!isAdmin) {
+        res.status(403).json({ error: 'Access denied', message: 'Only administrators can modify this page' });
+        return null;
+      }
+      return { pageData, wikiContext, pageName };
+    }
+
+    const allowed = await this.engine
+      .getManager('ACLManager')
+      ?.checkPagePermissionWithContext(wikiContext, action);
+    if (!allowed) {
+      res.status(403).json({ error: 'Access denied', message: `You do not have permission to ${action} this page` });
+      return null;
+    }
+
+    return { pageData, wikiContext, pageName };
+  }
+
+  /**
+   * DELETE /api/page/:identifier — delete a page (#946 slice 2).
+   *
+   * The JSON counterpart to `POST /delete/:page`. Slice 1 shipped tokens that
+   * could carry `page-delete`, but nothing behind it: deletion existed only as
+   * a session/form-shaped route returning HTML or a redirect. Letting agents
+   * drive that would have worked mechanically — bearer requests are CSRF-exempt
+   * — but it is an accidental API with no stable contract.
+   *
+   * Since #947 a delete is recoverable for the retention window, so this is no
+   * longer the irreversible operation the original slice-2 analysis assumed.
+   */
+  async apiDeletePage(req: Request, res: Response) {
+    const _metricsStart = Date.now();
+    try {
+      const prepared = await this.prepareApiPageMutation(req, res, 'delete');
+      if (!prepared) return;
+      const { pageData, wikiContext, pageName } = prepared;
+
+      const uuid = (pageData.metadata as { uuid?: string } | undefined)?.uuid ?? pageName;
+      const referringPages = this.engine.getManager('RenderingManager')?.getReferringPages(pageName) ?? [];
+
+      await this.auditPageDelete(req, wikiContext, pageName, uuid);
+
+      const deleted = await this.engine.getManager('PageManager')?.deletePageWithContext(wikiContext);
+      if (!deleted) {
+        return res.status(500).json({ error: 'Delete failed', pageName });
+      }
+
+      await this.reconcileIndexesAfterDelete(pageName, uuid, referringPages);
+      this.engine.getManager('MetricsManager')?.recordPageDelete?.(Date.now() - _metricsStart);
+
+      logger.info(`[WikiRoutes] API delete of '${pageName}' (${uuid}) by ${req.userContext!.username}`);
+      return res.json({ success: true, pageName, uuid, recoverable: true });
+    } catch (error: unknown) {
+      logger.error(`API delete failed: ${getErrorMessage(error)}`);
+      return res.status(500).json({ error: 'Internal server error', details: getErrorMessage(error) });
+    }
+  }
+
+  /**
+   * POST /api/page/:identifier/rename — rename a page (#946 slice 2).
+   *
+   * Body: `{ "newTitle": "..." }`
+   *
+   * There was no rename route at all before this — renaming was a side effect
+   * of saving with a changed `metadata.title`, reachable only through the edit
+   * form. This exposes it directly and reuses that same save path, so rename
+   * semantics stay identical however they are invoked.
+   *
+   * Unlike delete, a rename has no safety net: #947 does not cover it, and the
+   * old title is simply gone. Hence the conflict check below.
+   */
+  async apiRenamePage(req: Request, res: Response) {
+    try {
+      const prepared = await this.prepareApiPageMutation(req, res, 'rename');
+      if (!prepared) return;
+      const { pageData, wikiContext, pageName } = prepared;
+
+      const newTitle = typeof req.body?.newTitle === 'string' ? req.body.newTitle.trim() : '';
+      if (!newTitle) {
+        return res.status(400).json({ error: 'newTitle is required' });
+      }
+      if (newTitle === pageName) {
+        return res.status(400).json({ error: 'newTitle is the same as the current title' });
+      }
+
+      const pageManager = this.engine.getManager('PageManager');
+
+      // Refuse rather than overwrite. Saving onto an existing title would merge
+      // two pages into one and lose the target's content silently.
+      const existing = await pageManager?.getPage(newTitle);
+      if (existing) {
+        return res.status(409).json({
+          error: 'Title already in use',
+          message: `A page titled '${newTitle}' already exists`
+        });
+      }
+
+      const oldReferringPages = this.engine.getManager('RenderingManager')?.getReferringPages(pageName) ?? [];
+      const metadata = { ...(pageData.metadata ?? {}), title: newTitle };
+
+      (wikiContext as { content: string | null }).content = pageData.content;
+      await pageManager.savePageWithContext(wikiContext, metadata);
+
+      // Same index reconciliation the form save performs on a rename.
+      const renderingManager = this.engine.getManager('RenderingManager');
+      const searchManager = this.engine.getManager('SearchManager');
+      renderingManager?.removePageFromLinkGraph(pageName);
+      renderingManager?.addPageToCache(newTitle);
+      renderingManager?.updatePageInLinkGraph(newTitle, pageData.content);
+      await searchManager?.removePageFromIndex(pageName);
+      await searchManager?.updatePageInIndex(newTitle, {
+        name: newTitle,
+        content: pageData.content,
+        metadata
+      });
+
+      const cacheManager = this.engine.getManager('CacheManager');
+      if (cacheManager?.isInitialized?.()) {
+        // The uuid is stable across a rename, so one clear covers both titles.
+        const uuid = pageManager?.getPageUUID?.(newTitle) ?? newTitle;
+        await cacheManager.clear(undefined, `rendered-pages:${uuid}:*`);
+        for (const refPage of oldReferringPages) {
+          const refUUID = pageManager?.getPageUUID?.(refPage) ?? refPage;
+          await cacheManager.clear(undefined, `rendered-pages:${refUUID}:*`);
+        }
+      }
+
+      logger.info(`[WikiRoutes] API rename '${pageName}' → '${newTitle}' by ${req.userContext!.username}`);
+      return res.json({ success: true, from: pageName, to: newTitle });
+    } catch (error: unknown) {
+      logger.error(`API rename failed: ${getErrorMessage(error)}`);
+      return res.status(500).json({ error: 'Internal server error', details: getErrorMessage(error) });
+    }
+  }
+
+  /**
+   * Drop a deleted page from every derived index and cache (#946 slice 2).
+   *
+   * Extracted from {@link deletePage} so the JSON API delete performs exactly
+   * the same reconciliation. Two copies of this would drift, and the symptom of
+   * drift is a deleted page that still appears in search — silent and slow to
+   * notice.
+   *
+   * @param pageName - Title the page was deleted under
+   * @param uuid - Page uuid, captured before deletion emptied the cache
+   * @param referringPages - Pages that linked to it, captured before the link graph entry went
+   */
+  private async reconcileIndexesAfterDelete(
+    pageName: string,
+    uuid: string,
+    referringPages: string[]
+  ): Promise<void> {
+    logger.debug('🔄 Updating indexes after deletion...');
+    const pageManager = this.engine.getManager('PageManager');
+    this.engine.getManager('RenderingManager')?.removePageFromLinkGraph(pageName);
+    await this.engine.getManager('SearchManager')?.removePageFromIndex(pageName);
+
+    // Clear rendered cache for deleted page and any pages that linked to it
+    const cacheManager = this.engine.getManager('CacheManager');
+    if (cacheManager?.isInitialized?.()) {
+      await cacheManager.clear(undefined, `rendered-pages:${uuid}:*`);
+      for (const refPage of referringPages) {
+        const refUUID = pageManager?.getPageUUID?.(refPage) ?? refPage;
+        await cacheManager.clear(undefined, `rendered-pages:${refUUID}:*`);
+      }
+    }
+  }
+
+  /**
+   * Record a delete in the audit trail BEFORE it executes (#946 slice 2).
+   *
+   * Deliberately pre-execution: the audit entry has to survive the thing it
+   * describes. It captures the page name, uuid and — when the caller is an
+   * agent — the token id, so a destructive token can be traced to the token
+   * rather than only to the user who minted it.
+   *
+   * Best-effort: a failing audit backend must not block the delete.
+   */
+  private async auditPageDelete(
+    req: Request,
+    wikiContext: { userContext?: { username?: string } | null },
+    pageName: string,
+    uuid: string
+  ): Promise<void> {
+    try {
+      const auditManager = this.engine.getManager('AuditManager') as {
+        logAuditEvent?: (event: Record<string, unknown>) => Promise<string>;
+      } | null;
+      if (!auditManager?.logAuditEvent) return;
+
+      const viaToken = (req.userContext as { viaToken?: { id?: string; name?: string } } | undefined)?.viaToken;
+
+      await auditManager.logAuditEvent({
+        eventType: 'page.delete',
+        user: wikiContext.userContext?.username ?? 'unknown',
+        ipAddress: req.ip,
+        action: 'page-delete',
+        result: 'attempted',
+        severity: viaToken ? 'high' : 'medium',
+        metadata: {
+          pageName,
+          uuid,
+          viaTokenId: viaToken?.id ?? null,
+          viaTokenName: viaToken?.name ?? null
+        }
+      });
+    } catch (auditErr) {
+      logger.warn(`Audit log failed for page.delete of '${pageName}':`, auditErr);
+    }
+  }
+
   async deletePage(req: Request, res: Response) {
     const _metricsStart = Date.now();
     try {
@@ -3860,7 +4148,6 @@ ${panes}
       const currentUser = wikiContext.userContext;
       const pageManager = this.engine.getManager('PageManager');
       const renderingManager = this.engine.getManager('RenderingManager');
-      const searchManager = this.engine.getManager('SearchManager');
       const userManager = this.engine.getManager('UserManager');
       const aclManager = this.engine.getManager('ACLManager');
 
@@ -3924,25 +4211,18 @@ ${panes}
       // Capture referring pages before deletion removes the link graph entry
       const _deleteRefPages = renderingManager.getReferringPages(pageName);
 
+      // Audit BEFORE the delete executes (#946 slice 2). Writing it afterwards
+      // would lose the page name and uuid on any path where the delete
+      // succeeded but the process died before the audit landed — exactly the
+      // case an investigator needs.
+      await this.auditPageDelete(req, wikiContext, pageName, _deleteUUID);
+
       // Delete the page using WikiContext (includes audit logging with user info)
       const deleteResult = await pageManager.deletePageWithContext(wikiContext);
       logger.debug(`🗑️ Delete result: ${deleteResult}`);
 
       if (deleteResult) {
-        // Use incremental removal instead of full rebuilds for performance
-        logger.debug('🔄 Updating indexes after deletion...');
-        renderingManager.removePageFromLinkGraph(pageName);
-        await searchManager.removePageFromIndex(pageName);
-
-        // Clear rendered cache for deleted page and any pages that linked to it
-        const cacheManager = this.engine.getManager('CacheManager');
-        if (cacheManager?.isInitialized?.()) {
-          await cacheManager.clear(undefined, `rendered-pages:${_deleteUUID}:*`);
-          for (const refPage of _deleteRefPages) {
-            const refUUID = pageManager?.getPageUUID?.(refPage) ?? refPage;
-            await cacheManager.clear(undefined, `rendered-pages:${refUUID}:*`);
-          }
-        }
+        await this.reconcileIndexesAfterDelete(pageName, _deleteUUID, _deleteRefPages);
 
         logger.debug(`✅ Page deleted successfully: ${pageName}`);
         this.engine.getManager('MetricsManager')?.recordPageDelete?.(Date.now() - _metricsStart);
@@ -11445,6 +11725,14 @@ ${panes}
     );
     app.post('/api/page/:identifier/restore/:version', (req: Request, res: Response) =>
       this.restorePageVersion(req, res)
+    );
+
+    // #946 slice 2 — JSON mutation API for agent tokens (and anyone else)
+    app.delete('/api/page/:identifier', (req: Request, res: Response) =>
+      this.apiDeletePage(req, res)
+    );
+    app.post('/api/page/:identifier/rename', (req: Request, res: Response) =>
+      this.apiRenamePage(req, res)
     );
 
     // #947 trash API — admin-only, enforced inside each handler

--- a/src/utils/__tests__/AgentMutationRateLimiter.test.ts
+++ b/src/utils/__tests__/AgentMutationRateLimiter.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @file AgentMutationRateLimiter.test.ts
+ * @description #946 slice 2 — the token-mutation rate limiter.
+ *
+ * Deferred in slice 1 because ingest is an idempotent upsert. Delete and rename
+ * are neither idempotent nor self-correcting, and a token runs unattended for up
+ * to 24 hours.
+ */
+import { SimpleRateLimiter } from '../SimpleRateLimiter';
+
+describe('agent mutation rate limiter (#946 slice 2)', () => {
+  const OPTS = { max: 60, windowMs: 60 * 1000 };
+
+  test('allows a legitimate editing rate', () => {
+    const limiter = new SimpleRateLimiter(OPTS);
+    for (let i = 0; i < 60; i++) {
+      expect(limiter.consume('tok_a').allowed).toBe(true);
+    }
+  });
+
+  test('stops a runaway loop once the budget is spent', () => {
+    const limiter = new SimpleRateLimiter(OPTS);
+    for (let i = 0; i < 60; i++) limiter.consume('tok_a');
+
+    const blocked = limiter.consume('tok_a');
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  test('one runaway token does not starve another', () => {
+    // Keyed by token id precisely so a misbehaving agent is contained.
+    const limiter = new SimpleRateLimiter(OPTS);
+    for (let i = 0; i < 61; i++) limiter.consume('tok_runaway');
+
+    expect(limiter.consume('tok_runaway').allowed).toBe(false);
+    expect(limiter.consume('tok_wellbehaved').allowed).toBe(true);
+  });
+
+  test('the budget refills after the window', () => {
+    vi.useFakeTimers();
+    try {
+      const limiter = new SimpleRateLimiter(OPTS);
+      for (let i = 0; i < 61; i++) limiter.consume('tok_a');
+      expect(limiter.consume('tok_a').allowed).toBe(false);
+
+      vi.advanceTimersByTime(60 * 1000 + 1);
+
+      expect(limiter.consume('tok_a').allowed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/e2e/agent-token-mutations.spec.ts
+++ b/tests/e2e/agent-token-mutations.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * #946 slice 2 — DELETE /api/page/:identifier and POST /api/page/:identifier/rename,
+ * exercised through a real agent token.
+ *
+ * Slice 1's lesson was that unit tests are not enough here: two bugs (the scope
+ * ceiling not holding on the real permission path, and `page-ingest` not being
+ * an action name) passed the entire unit suite and only failed against a running
+ * server. So the scope enforcement below is deliberately tested end to end.
+ */
+
+const PREFIX = 'NGDPBASE-test-946';
+
+const csrf = async (request) => {
+  const html = await (await request.get('/login')).text();
+  const m = html.match(/<meta name="csrf-token" content="([^"]+)"/);
+  if (!m) throw new Error('no csrf token');
+  return m[1];
+};
+
+const sessionHeaders = async (request) => ({
+  Accept: 'application/json',
+  'X-CSRF-Token': await csrf(request)
+});
+
+/** Mint a token for the logged-in admin, or skip if the feature is disabled. */
+async function mint(request, name, scopes) {
+  const res = await request.post('/api/tokens', {
+    headers: { ...(await sessionHeaders(request)), 'Content-Type': 'application/json' },
+    data: { name, scopes, ttlHours: 1 }
+  });
+  if (res.status() === 404 || res.status() === 501) return null;
+  const body = await res.json();
+  if (!body.success) throw new Error(`mint failed: ${JSON.stringify(body)}`);
+  return { token: body.token, id: body.record?.id ?? body.id };
+}
+
+/**
+ * Everything this spec creates, cleaned in afterEach REGARDLESS of outcome.
+ *
+ * The first version revoked at the end of each test body, which leaks on every
+ * failure — and failures are exactly when cleanup matters, because a retry
+ * mints again. Three failing runs exhausted the admin's 10-live-token budget
+ * and the suite then failed with "Token limit reached" for reasons that had
+ * nothing to do with the code under test.
+ */
+const minted: string[] = [];
+const pages: string[] = [];
+
+/** Mint and register for cleanup. Returns null when the feature is disabled. */
+async function mintTracked(request, name, scopes) {
+  const m = await mint(request, name, scopes);
+  if (m?.id) minted.push(m.id);
+  return m;
+}
+
+/** Create a page through the normal save route. */
+async function makePage(request, title, content = 'seed content') {
+  const res = await request.post(`/save/${encodeURIComponent(title)}`, {
+    headers: await sessionHeaders(request),
+    form: { pageName: title, content, 'system-category': 'General' }
+  });
+  expect([200, 302]).toContain(res.status());
+}
+
+/** Create a page and register it for cleanup. */
+async function makeTrackedPage(request, title, content = 'seed content') {
+  pages.push(title);
+  await makePage(request, title, content);
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('#946 slice 2 — agent token page mutations', () => {
+  test.afterEach(async ({ request }) => {
+    const headers = await sessionHeaders(request);
+
+    while (minted.length) {
+      await request.delete(`/api/tokens/${minted.pop()}`, { headers }).catch(() => {});
+    }
+
+    while (pages.length) {
+      const name = pages.pop();
+      await request.post(`/delete/${encodeURIComponent(name)}`, { headers }).catch(() => {});
+    }
+
+    // Purge the #947 tombstones so test pages leave no storage behind.
+    const trash = await (await request.get('/api/admin/deleted-pages')).json().catch(() => ({ pages: [] }));
+    for (const entry of (trash.pages || []).filter((p) => String(p.title).startsWith(PREFIX))) {
+      await request.delete(`/api/admin/deleted-pages/${entry.uuid}`, { headers }).catch(() => {});
+    }
+  });
+
+  test('a token scoped to delete can delete, and the page is recoverable', async ({ request }) => {
+    const minted = await mintTracked(request, `${PREFIX}-del`, ['page-ingest', 'page-delete']);
+    test.skip(!minted, 'agent tokens disabled on this instance');
+
+    const title = `${PREFIX}-delete-${Date.now()}`;
+    await makeTrackedPage(request, title);
+
+    const res = await request.delete(`/api/page/${encodeURIComponent(title)}`, {
+      headers: { Authorization: `Bearer ${minted.token}`, Accept: 'application/json' }
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: true, pageName: title, recoverable: true });
+
+    expect((await request.get(`/view/${encodeURIComponent(title)}`)).status()).toBe(404);
+
+    // #947: it must be in the trash, not destroyed.
+    const trash = await (await request.get('/api/admin/deleted-pages')).json();
+    expect(trash.pages.find((p) => p.title === title)).toBeTruthy();
+  });
+
+  test('a token WITHOUT page-delete is refused (scope ceiling holds on the real path)', async ({ request }) => {
+    const minted = await mintTracked(request, `${PREFIX}-noscope`, ['page-ingest']);
+    test.skip(!minted, 'agent tokens disabled on this instance');
+
+    const title = `${PREFIX}-refused-${Date.now()}`;
+    await makeTrackedPage(request, title);
+
+    const res = await request.delete(`/api/page/${encodeURIComponent(title)}`, {
+      headers: { Authorization: `Bearer ${minted.token}`, Accept: 'application/json' }
+    });
+    expect(res.status()).toBe(403);
+
+    // The page must still be there — a refused delete that half-executed would
+    // be worse than one that errored.
+    expect((await request.get(`/view/${encodeURIComponent(title)}`)).status()).toBe(200);
+
+  });
+
+  test('a token scoped to rename can rename', async ({ request }) => {
+    const minted = await mintTracked(request, `${PREFIX}-ren`, ['page-ingest', 'page-rename']);
+    test.skip(!minted, 'agent tokens disabled on this instance');
+
+    const from = `${PREFIX}-from-${Date.now()}`;
+    const to = `${PREFIX}-to-${Date.now()}`;
+    await makeTrackedPage(request, from, 'content that must survive the rename');
+    pages.push(to);
+
+    const res = await request.post(`/api/page/${encodeURIComponent(from)}/rename`, {
+      headers: { Authorization: `Bearer ${minted.token}`, 'Content-Type': 'application/json' },
+      data: { newTitle: to }
+    });
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, from, to });
+
+    const moved = await request.get(`/view/${encodeURIComponent(to)}`);
+    expect(moved.status()).toBe(200);
+    expect(await moved.text()).toContain('content that must survive the rename');
+
+  });
+
+  test('rename refuses to overwrite an existing title', async ({ request }) => {
+    const a = `${PREFIX}-conflict-a-${Date.now()}`;
+    const b = `${PREFIX}-conflict-b-${Date.now()}`;
+    await makeTrackedPage(request, a, 'page A');
+    await makeTrackedPage(request, b, 'page B');
+
+    const res = await request.post(`/api/page/${encodeURIComponent(a)}/rename`, {
+      headers: { ...(await sessionHeaders(request)), 'Content-Type': 'application/json' },
+      data: { newTitle: b }
+    });
+    expect(res.status()).toBe(409);
+
+    // Both pages intact — B in particular must not have been clobbered.
+    expect(await (await request.get(`/view/${encodeURIComponent(b)}`)).text()).toContain('page B');
+    expect((await request.get(`/view/${encodeURIComponent(a)}`)).status()).toBe(200);
+
+  });
+
+  test('unauthenticated mutations are rejected', async ({ playwright }) => {
+    const anon = await playwright.request.newContext();
+    // 403 in practice, not 401: the CSRF guard sits in front of the handler and
+    // rejects the session-less request before it reaches the auth check. Either
+    // is a refusal; what matters is that it never reaches the delete.
+    expect([401, 403]).toContain((await anon.delete('/api/page/Welcome')).status());
+    await anon.dispose();
+  });
+
+  test('a missing page returns 404, not a 500', async ({ request }) => {
+    const res = await request.delete(`/api/page/${PREFIX}-does-not-exist`, { headers: await sessionHeaders(request) });
+    expect(res.status()).toBe(404);
+  });
+});

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -190,9 +190,15 @@
                                             <div class="col-md-4">
                                                 <label class="form-label small mb-1" for="agent-token-scopes">Permissions</label>
                                                 <select class="form-select form-select-sm" id="agent-token-scopes">
-                                                    <option value="page-ingest" selected>Create and edit pages</option>
                                                     <option value="page-read">Read only</option>
+                                                    <option value="page-ingest" selected>Create and edit pages</option>
+                                                    <option value="page-ingest,page-rename">Create, edit and rename</option>
+                                                    <option value="page-ingest,page-rename,page-delete">Create, edit, rename and delete</option>
                                                 </select>
+                                                <div class="form-text">
+                                                    A token can never exceed your own permissions.
+                                                    Deleted pages stay recoverable from the trash.
+                                                </div>
                                             </div>
                                             <div class="col-md-2">
                                                 <label class="form-label small mb-1" for="agent-token-ttl">Hours</label>
@@ -824,7 +830,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': CSRF },
                 body: JSON.stringify({
                     name: document.getElementById('agent-token-name').value,
-                    scopes: [document.getElementById('agent-token-scopes').value],
+                    // The picker offers combined options ("page-ingest,page-rename"),
+                    // so split rather than sending one comma-joined string as a single scope.
+                    scopes: document.getElementById('agent-token-scopes').value.split(','),
                     ttlHours: Number(document.getElementById('agent-token-ttl').value) || undefined
                 })
             });


### PR DESCRIPTION
Completes **#946** — slice 2.

## What was missing

Slice 1 shipped tokens that could carry `page-delete` and `page-rename` with **nothing behind them**. Deletion existed only as `POST /delete/:page` — a session/form-shaped route returning HTML or a redirect — and there was no rename route at all.

Agents *could* have driven the form routes (bearer requests are CSRF-exempt), but that's an accidental API: no stable contract, HTML-shaped responses, and it entangles agent behaviour with browser flows.

```text
DELETE /api/page/:identifier
POST   /api/page/:identifier/rename    { "newTitle": "..." }
```

Both resolve uuid/slug/title, enforce the same required-page admin rule and ACL actions as the form routes, and answer JSON throughout.

## The parts that are easy to get wrong

**Index reconciliation is now one shared function.** The form route and the API both call it. Two copies drift, and the symptom of drift is a deleted page that still shows up in search — silent and slow to notice.

**The delete audit is written *before* the delete runs**, carrying page name, uuid and (for agents) the token id. Written afterwards it's lost on any path where the delete succeeded but the process died first — exactly the case an investigator needs. Severity is `high` when the caller is a token.

**Rename refuses an in-use title (409).** Saving onto an existing title would merge two pages and silently lose the target's content. Unlike delete, rename has no #947 safety net — the old title is simply gone.

**Rate limiting**, deferred in slice 1 because ingest is an idempotent upsert. Delete and rename are neither. Keyed by token id so one runaway agent can't starve another; human callers aren't limited, because being a human *is* the rate limit. #947 lowered the severity here — a delete is now recoverable — but didn't remove the need.

## The scopes never needed "unlocking"

The issue framed slice 2 as unlocking `page-delete` / `page-rename`. Reading the code, mint only ever refused `admin-*` — those scopes were **already mintable**. The real gate was the profile UI, which offered exactly two options. It now offers rename and delete as well.

## Tests

4 unit (the limiter) + 7 E2E driving **real tokens** end to end.

That split is deliberate. Slice 1's two bugs — the scope ceiling not holding on the live permission path, and `page-ingest` not being an action name — both passed the full unit suite and only failed against a running server. The scope-ceiling case is now covered there: a token *without* `page-delete` is refused, and the page is asserted still present afterwards.

Two things the E2E suite learned the hard way, both encoded in comments so nobody "fixes" them back:

- **Serial by necessity.** Every test mints against the same admin user, and the cap is 10 *live* tokens. Run in parallel they race for that budget and fail with `Token limit reached` for reasons unrelated to the code.
- **Cleanup in `afterEach`, not at the end of the test body.** End-of-body cleanup leaks on exactly the runs where it matters — failures — which then retry and mint again. Three failed runs exhausted the token budget before I moved it.

## Verification

On jimstest with tokens enabled: **6763 unit**, **85 E2E**. A full run leaves **0 test pages, 0 tombstones, 0 live test tokens**.

While verifying I also swept pre-existing debris: the four stale `NGDPBASE-test-LocationTest-*` pages from #970, plus leaked tokens from my own failing iterations.
