### PR TITLE
fix(chrome): warn when a permission decision blanks site chrome (#950)

### DIFF
--- a/src/routes/WikiRoutes.ts
+++ b/src/routes/WikiRoutes.ts
@@ -913,6 +913,7 @@ class WikiRoutes {
       const canViewLeftMenu = leftMenuCtx !== null
         && await aclManager.checkPagePermissionWithContext(leftMenuCtx, 'view');
       logger.info(`[TEMPLATE] LeftMenu ACL decision: ${canViewLeftMenu}`);
+      this.warnOnChromeDenial('LeftMenu', canViewLeftMenu, leftMenuCtx !== null, userContext);
 
       if (canViewLeftMenu && leftMenuCtx !== null && leftMenuContent !== null) {
         templateData.leftMenu = await renderingManager.textToHTML(
@@ -957,6 +958,7 @@ class WikiRoutes {
       const canViewFooter = footerCtx !== null
         && await aclManager.checkPagePermissionWithContext(footerCtx, 'view');
       logger.info(`[TEMPLATE] Footer ACL decision: ${canViewFooter}`);
+      this.warnOnChromeDenial('Footer', canViewFooter, footerCtx !== null, userContext);
 
       if (canViewFooter && footerCtx !== null && footerContent !== null) {
         templateData.footer = await renderingManager.textToHTML(
@@ -3863,6 +3865,46 @@ ${panes}
   /**
    * Delete a page
    */
+  /**
+   * Log loudly when a permission decision blanks site chrome (#950).
+   *
+   * `LeftMenu` and `Footer` are fragments rendered into every page, not
+   * destinations that are visited. When the ACL evaluator denies one, the
+   * fragment is replaced with an empty string and the affected user loses the
+   * sidebar or footer on **every page of the site** — previously with nothing
+   * at warn or error, and the decision logged at `info` looking exactly like
+   * ordinary traffic. It presents as "the nav disappeared for some users" with
+   * nothing pointing at permissions.
+   *
+   * This does not change the gating behaviour. Whether fragments should be
+   * audience-gated at all is the broader design question in #950 and is an
+   * operator call, not a side effect of adding a log line. It only makes the
+   * failure visible, and distinguishes it from the ordinary "no chrome page
+   * configured" case, which is not a problem at all.
+   *
+   * @param label - Chrome slot being rendered, for the message
+   * @param allowed - The ACL verdict
+   * @param pageExists - Whether a chrome page was resolved at all
+   * @param userContext - Who the decision applied to
+   */
+  private warnOnChromeDenial(
+    label: 'LeftMenu' | 'Footer',
+    allowed: boolean,
+    pageExists: boolean,
+    userContext: { username?: string; roles?: string[] } | null | undefined
+  ): void {
+    // No chrome page configured is normal — say nothing.
+    if (!pageExists || allowed) return;
+
+    logger.warn(
+      `[TEMPLATE] ${label} suppressed by a permission decision — this user sees NO ${label} on ` +
+      `every page of the site. user=${userContext?.username ?? 'anonymous'} ` +
+      `roles=[${userContext?.roles?.join(',') ?? ''}]. ` +
+      'Site chrome is a fragment, not a destination: check for frontmatter audience/access or ' +
+      `private:true on the ${label} page, or a deny policy covering it (#950).`
+    );
+  }
+
   /**
    * Guard shared by the #946 slice-2 mutation endpoints.
    *

--- a/src/routes/__tests__/WikiRoutes-ChromeDenial.test.ts
+++ b/src/routes/__tests__/WikiRoutes-ChromeDenial.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @file WikiRoutes-ChromeDenial.test.ts
+ * @description #950 — a permission decision that blanks site chrome must be
+ * visible in the logs.
+ *
+ * LeftMenu and Footer are fragments rendered into every page. When one is
+ * denied the user loses it site-wide, and before this the only trace was an
+ * `info` line indistinguishable from ordinary traffic.
+ */
+import logger from '../../utils/logger';
+
+// The method under test is private and has no manager dependencies, so it is
+// exercised directly rather than by standing up the whole render path.
+type ChromeWarner = {
+  warnOnChromeDenial(
+    label: 'LeftMenu' | 'Footer',
+    allowed: boolean,
+    pageExists: boolean,
+    userContext: { username?: string; roles?: string[] } | null | undefined
+  ): void;
+};
+
+describe('#950 chrome denial logging', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  let routes: ChromeWarner;
+
+  beforeEach(async () => {
+    warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    // spyOn reuses an existing spy, so recorded calls survive restoreAllMocks
+    // and leak between cases.
+    warn.mockClear();
+    const mod = await import('../WikiRoutes');
+    const WikiRoutes = (mod.default ?? mod) as unknown as { prototype: ChromeWarner };
+    routes = Object.create(WikiRoutes.prototype) as ChromeWarner;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('warns when a resolved chrome page is denied', () => {
+    routes.warnOnChromeDenial('LeftMenu', false, true, { username: 'bob', roles: ['reader'] });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0][0]);
+    expect(message).toContain('LeftMenu suppressed by a permission decision');
+    expect(message).toContain('bob');
+    // The message must say the blast radius is the whole site, not one page.
+    expect(message).toContain('every page of the site');
+  });
+
+  test('says nothing when the chrome page renders normally', () => {
+    routes.warnOnChromeDenial('LeftMenu', true, true, { username: 'bob' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('says nothing when no chrome page is configured', () => {
+    // The common, entirely healthy case — an instance with no LeftMenu at all.
+    // Warning here would train operators to ignore the message.
+    routes.warnOnChromeDenial('Footer', false, false, { username: 'bob' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('handles an anonymous user without throwing', () => {
+    routes.warnOnChromeDenial('Footer', false, true, null);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('anonymous');
+  });
+});


### PR DESCRIPTION
Narrow fix for #950.

## The problem

`LeftMenu` and `Footer` are fragments rendered into every page. When the ACL evaluator denies one, it is replaced with an empty string and the user loses the sidebar or footer on **every page of the site** — with nothing at warn or error, and the decision logged at `info` looking exactly like ordinary traffic.

It presents as *"the nav disappeared for some users"* with nothing pointing at permissions.

## The fix

Log at warn, naming the user, their roles, the blast radius, and the three things that can cause it (frontmatter `audience`/`access`, `private: true`, a deny policy).

**Silent when no chrome page is configured** — the common healthy case on a stock instance. Warning there would train operators to ignore the message, leaving the real failure as invisible as before. There is a test for that.

## What this deliberately does NOT do

It does not change the gating behaviour. Whether fragments should be audience-gated at all is the broader design question recorded in #950, and that is an operator call rather than a side effect of adding a log line.

**So #950 should stay open** after this merges, narrowed to that question.

## Verification

4 new tests. Suite 6767 passed, tsc and lint clean.