### PR TITLE
fix(pages): detect and report required pages missing after install (#954)

### DIFF
--- a/src/managers/PageManager.ts
+++ b/src/managers/PageManager.ts
@@ -292,12 +292,17 @@ class PageManager extends BaseManager implements CatalogSource {
       const dataDir = path.dirname(pagesDirResolved);
       const installCompletePath = path.join(dataDir, '.install-complete');
 
-      // Check conditions: skip if install is already complete AND pages exist
+      // Check conditions: skip SEEDING if install is already complete AND pages
+      // exist — but not silently. #954: this used to return outright, which made
+      // the function a first-install seeder and nothing else. A required page
+      // deleted later was never noticed, never re-seeded and never reported, at
+      // any point, ever. Established instances now get an integrity check.
       const installComplete: boolean = await fse.pathExists(installCompletePath);
       if (installComplete) {
         const existing: string[] = await fse.readdir(pagesDirResolved).catch(() => []);
         if (existing.filter((f: string) => f.endsWith('.md')).length > 0) {
           logger.debug('[PageManager] Required pages seed skipped — installation already complete');
+          await this.reportMissingRequiredPages(configManager, pagesDirResolved);
           return;
         }
       }
@@ -381,6 +386,95 @@ class PageManager extends BaseManager implements CatalogSource {
       }
     } catch (err) {
       logger.error('[PageManager] Failed to seed required pages:', err);
+    }
+  }
+
+  /**
+   * Report required pages that are missing from an established instance (#954).
+   *
+   * `seedRequiredPages` only ever ran on a fresh install, so a required page
+   * deleted afterwards was invisible forever — no log, no notification, no
+   * re-seed. The page simply stopped existing and nothing said so.
+   *
+   * **Reports; never re-seeds.** Silently restoring pages at boot would fight
+   * the operator: a required page can be deleted deliberately, and since #947 a
+   * delete is a recoverable soft delete, so resurrecting a copy at boot would
+   * leave a live page *and* a tombstone of the same thing. Detection is the
+   * missing capability here; the remedy is already available through the admin
+   * Required Pages Sync tool, and choosing to apply it belongs to the operator.
+   *
+   * Best-effort: a failure here must never block startup.
+   *
+   * @param configManager - For the required-pages directory and category catalog
+   * @param pagesDirResolved - Live page storage directory
+   */
+  private async reportMissingRequiredPages(
+    configManager: ConfigurationManager,
+    pagesDirResolved: string
+  ): Promise<void> {
+    try {
+      const requiredDirRaw: string = configManager.getProperty(
+        'ngdpbase.page.provider.filesystem.requiredpagesdir',
+        './required-pages'
+      ) as string;
+      const requiredDir = path.isAbsolute(requiredDirRaw)
+        ? requiredDirRaw
+        : path.join(process.cwd(), requiredDirRaw);
+
+      if (!(await fse.pathExists(requiredDir))) return;
+
+      // github-only pages live in the source tree by design and are never
+      // seeded, so their absence is correct rather than a defect.
+      const systemCategories = configManager.getProperty('ngdpbase.system-category', {}) as
+        Record<string, { storageLocation?: string }>;
+      const githubOnlyCategories = new Set(
+        Object.entries(systemCategories)
+          .filter(([, cfg]) => cfg.storageLocation === 'github')
+          .map(([key]) => key)
+      );
+
+      const files: string[] = (await fse.readdir(requiredDir)).filter((f: string) => f.endsWith('.md'));
+      const missing: string[] = [];
+
+      for (const file of files) {
+        if (await fse.pathExists(path.join(pagesDirResolved, file))) continue;
+
+        const raw: string = await fse.readFile(path.join(requiredDir, file), 'utf8');
+        const parsed = matter(raw) as { data: Record<string, unknown>; content: string };
+        const category = parsed.data['system-category'] as string | undefined;
+        if (category && githubOnlyCategories.has(category)) continue;
+
+        const title = typeof parsed.data['title'] === 'string' ? parsed.data['title'] : file;
+        missing.push(title);
+      }
+
+      if (missing.length === 0) {
+        logger.debug('[PageManager] Required-pages integrity check passed');
+        return;
+      }
+
+      logger.warn(
+        `[PageManager] ${missing.length} required page(s) missing from storage: ${missing.join(', ')}. ` +
+        'They are NOT re-seeded automatically — use the admin Required Pages Sync tool to restore ' +
+        'any that were removed by accident (#954).'
+      );
+
+      try {
+        const notificationManager = this.engine.getManager<NotificationManager>('NotificationManager');
+        await notificationManager?.createNotification?.({
+          type: 'system',
+          level: 'warning',
+          title: 'Required pages missing',
+          message:
+            `${missing.length} required page${missing.length === 1 ? '' : 's'} ` +
+            `${missing.length === 1 ? 'is' : 'are'} missing from storage: ${missing.join(', ')}. ` +
+            'Restore from Admin → Required Pages Sync if this was not intentional.'
+        });
+      } catch {
+        // non-fatal
+      }
+    } catch (err) {
+      logger.error('[PageManager] Required-pages integrity check failed:', err);
     }
   }
 

--- a/src/managers/__tests__/PageManager-RequiredPagesIntegrity.test.ts
+++ b/src/managers/__tests__/PageManager-RequiredPagesIntegrity.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @file PageManager-RequiredPagesIntegrity.test.ts
+ * @description #954 — a required page deleted after install must be detected
+ * and reported.
+ *
+ * `seedRequiredPages` was a first-install seeder only: on any established
+ * instance it returned immediately, so a later deletion was never noticed,
+ * never re-seeded and never reported.
+ */
+vi.unmock('../PageManager');
+
+import fse from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import matter from 'gray-matter';
+import logger from '../../utils/logger';
+
+type Integrity = {
+  reportMissingRequiredPages(configManager: unknown, pagesDir: string): Promise<void>;
+  engine: unknown;
+};
+
+describe('#954 required-pages integrity check', () => {
+  let testDir: string;
+  let requiredDir: string;
+  let pagesDir: string;
+  let warn: ReturnType<typeof vi.spyOn>;
+  let notify: ReturnType<typeof vi.fn>;
+  let manager: Integrity;
+
+  const writeRequired = async (file: string, data: Record<string, unknown>) => {
+    await fse.writeFile(path.join(requiredDir, file), matter.stringify('body', data), 'utf8');
+  };
+
+  beforeEach(async () => {
+    // Temp dirs only — never the live data/ tree.
+    testDir = path.join(os.tmpdir(), `required-integrity-${Date.now()}-${Math.floor(performance.now())}`);
+    requiredDir = path.join(testDir, 'required-pages');
+    pagesDir = path.join(testDir, 'pages');
+    await fse.ensureDir(requiredDir);
+    await fse.ensureDir(pagesDir);
+
+    warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    warn.mockClear();
+    notify = vi.fn().mockResolvedValue(undefined);
+
+    const configManager = {
+      getProperty: vi.fn((key: string, dflt: unknown) => {
+        if (key === 'ngdpbase.page.provider.filesystem.requiredpagesdir') return requiredDir;
+        if (key === 'ngdpbase.system-category') {
+          return { developer: { storageLocation: 'github' }, system: { storageLocation: 'required' } };
+        }
+        return dflt;
+      })
+    };
+
+    const mod = await import('../PageManager');
+    const PageManager = (mod.default ?? mod) as unknown as { prototype: Integrity };
+    manager = Object.create(PageManager.prototype) as Integrity;
+    (manager as { engine: unknown }).engine = {
+      getManager: (n: string) => (n === 'NotificationManager' ? { createNotification: notify } : null)
+    };
+    (manager as { cfg?: unknown }).cfg = configManager;
+    (globalThis as { __cfg?: unknown }).__cfg = configManager;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    // Only this test's own temp directory.
+    if (await fse.pathExists(testDir)) await fse.remove(testDir);
+  });
+
+  const cfg = () => (globalThis as { __cfg: unknown }).__cfg;
+
+  test('reports a required page that was deleted after install', async () => {
+    await writeRequired('a.md', { title: 'Welcome', 'system-category': 'system' });
+    // Deliberately NOT copied into pagesDir — it was deleted.
+
+    await manager.reportMissingRequiredPages(cfg(), pagesDir);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('Welcome');
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toMatchObject({ level: 'warning', title: 'Required pages missing' });
+  });
+
+  test('stays silent when every required page is present', async () => {
+    await writeRequired('a.md', { title: 'Welcome', 'system-category': 'system' });
+    await fse.copy(path.join(requiredDir, 'a.md'), path.join(pagesDir, 'a.md'));
+
+    await manager.reportMissingRequiredPages(cfg(), pagesDir);
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  test('does NOT report github-only pages as missing', async () => {
+    // These live in the source tree by design and are never seeded, so their
+    // absence is correct. Reporting them would make the check cry wolf on every
+    // boot of every instance.
+    await writeRequired('dev.md', { title: 'Developer Docs', 'system-category': 'developer' });
+
+    await manager.reportMissingRequiredPages(cfg(), pagesDir);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('never re-seeds the missing page', async () => {
+    // Reporting is the point; silently restoring would fight an operator who
+    // deleted it deliberately, and since #947 would leave a live page plus a
+    // tombstone of the same thing.
+    await writeRequired('a.md', { title: 'Welcome', 'system-category': 'system' });
+
+    await manager.reportMissingRequiredPages(cfg(), pagesDir);
+
+    expect(await fse.pathExists(path.join(pagesDir, 'a.md'))).toBe(false);
+  });
+
+  test('a missing required-pages directory is not an error', async () => {
+    await fse.remove(requiredDir);
+    await expect(manager.reportMissingRequiredPages(cfg(), pagesDir)).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #954.

## The problem

`seedRequiredPages()` was a first-install seeder and nothing else. On any established instance it returned immediately after a file count, so a required page deleted later was **never noticed, never re-seeded and never reported** — at any point, ever.

## The fix

Established instances now run an integrity check instead of returning: compare `required-pages/` against live storage, report anything absent at warn plus an operator notification naming the pages.

## Reports, never re-seeds

Deliberate. Silently restoring at boot would fight the operator — a required page can be deleted on purpose, and since #947 a delete is a *recoverable* soft delete, so resurrecting a copy would leave a live page **and** a tombstone of the same thing.

Detection was the missing capability. The remedy already exists in Admin → Required Pages Sync, and applying it is the operator’s call.

## Not crying wolf

`github-only` pages (`system-category` with `storageLocation: github`) are excluded. They live in the source tree by design and are never seeded, so their absence is correct — reporting them would fire on every boot of every instance, which is how a warning becomes background noise. There is a test for it.

## Verification

5 new tests, including the two that keep it honest: github-only pages are not reported, and the missing page is **not** restored.

Suite 6772 passed. On jimstest it boots clean with no warning, which is the expected result there — nothing is missing. Note the passing path logs at `debug`, so it is not visible at that instance’s `info` level; the unit tests are what pin the behaviour.