### PR TITLE
fix(addons): make page-level seed failures loud and catch duplicate uuids (#951)

### DIFF
--- a/src/managers/AddonsManager.ts
+++ b/src/managers/AddonsManager.ts
@@ -669,6 +669,46 @@ class AddonsManager extends BaseManager {
    * @param addonName  Name of the add-on (for logging)
    * @param addonPath  Filesystem path to the add-on directory
    */
+  /**
+   * Surface a page-level seed failure beyond the boot log (#951).
+   *
+   * A boot-time log line is invisible ten minutes later, which is how a page
+   * that never seeded stays missing for weeks. Raising an operator
+   * notification makes the failure outlive the boot it happened on.
+   *
+   * Deliberately NOT fail-fast. Refusing to start because a third-party addon
+   * shipped one malformed page turns an authoring typo into an outage, and the
+   * #672 precedent does not transfer — that was the operator's own config
+   * naming a nonexistent addon, which the operator can fix. A vendor's
+   * malformed file is not in the operator's control. Skip the page, report
+   * loudly, surface it after boot.
+   *
+   * Best-effort: notification failure must never break seeding.
+   */
+  private recordSeedFailure(
+    addonName: string,
+    file: string,
+    reason: 'missing-or-invalid-uuid' | 'duplicate-uuid' | 'missing-slug',
+    isDomain: boolean
+  ): void {
+    try {
+      const notificationManager = this.engine.getManager<{
+        createNotification?: (n: Record<string, unknown>) => Promise<unknown>;
+          }>('NotificationManager');
+
+      void notificationManager?.createNotification?.({
+        type: 'system',
+        level: isDomain ? 'error' : 'warning',
+        title: `Add-on page not seeded (${addonName})`,
+        message:
+          `${addonName}/pages/${file} was skipped: ${reason}. The page will not appear on this site.` +
+          (isDomain ? ' This is a domain add-on, so the site may be incomplete.' : '')
+      })?.catch?.(() => { /* non-fatal */ });
+    } catch {
+      // non-fatal
+    }
+  }
+
   private async seedAddonPages(addonName: string, addonPath: string): Promise<void> {
     const addonPagesDir = path.join(addonPath, 'pages');
 
@@ -698,6 +738,25 @@ class AddonsManager extends BaseManager {
 
     const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+    // #951: a domain addon's page failing to seed is a broken site; the same
+    // failure in an additive addon is a missing help page. Line ~535 already
+    // draws exactly this distinction for identity mismatch — page seeding now
+    // follows it instead of flattening both to `warn`.
+    const isDomain = this.addons.get(addonName)?.manifest?.type === 'domain';
+    const reportSkip = (message: string): void => {
+      if (isDomain) logger.error(message);
+      else logger.warn(message);
+    };
+
+    // #951: guard against two source pages sharing a uuid — the obvious
+    // copy-paste mistake when creating a page from an existing one. Without
+    // this the second file matches the first's already-seeded page and is
+    // silently skipped, so ONE PAGE SIMPLY NEVER APPEARS and the only trace is
+    // a debug line phrased as normal operation. With reseed enabled it is
+    // worse: the two files fight over one page and the winner depends on
+    // filesystem ordering.
+    const seenUuids = new Map<string, string>();
+
     for (const file of files) {
       const src = path.join(addonPagesDir, file);
       try {
@@ -707,12 +766,31 @@ class AddonsManager extends BaseManager {
         const slug = parsed.data.slug as string | undefined;
 
         if (!uuid || !uuidPattern.test(uuid)) {
-          logger.warn(`[AddonsManager] Skipping ${addonName}/pages/${file} — missing or invalid uuid in frontmatter`);
+          reportSkip(
+            `[AddonsManager] Skipping ${addonName}/pages/${file} — missing or invalid uuid in ` +
+            'frontmatter. The addon owns page uuids and they are mandatory; this page will not appear.'
+          );
+          this.recordSeedFailure(addonName, file, 'missing-or-invalid-uuid', isDomain);
           continue;
         }
 
+        const duplicateOf = seenUuids.get(uuid.toLowerCase());
+        if (duplicateOf) {
+          reportSkip(
+            `[AddonsManager] Skipping ${addonName}/pages/${file} — uuid ${uuid} is already used by ` +
+            `${duplicateOf}. Two source pages cannot share a uuid: one of them would never appear, ` +
+            'and with reseed enabled they fight over the same page. Give this page its own uuid.'
+          );
+          this.recordSeedFailure(addonName, file, 'duplicate-uuid', isDomain);
+          continue;
+        }
+        seenUuids.set(uuid.toLowerCase(), file);
+
         if (!slug) {
-          logger.warn(`[AddonsManager] Skipping ${addonName}/pages/${file} — missing slug in frontmatter`);
+          reportSkip(
+            `[AddonsManager] Skipping ${addonName}/pages/${file} — missing slug in frontmatter`
+          );
+          this.recordSeedFailure(addonName, file, 'missing-slug', isDomain);
           continue;
         }
 

--- a/src/managers/__tests__/AddonsManager-SeedFailures.test.ts
+++ b/src/managers/__tests__/AddonsManager-SeedFailures.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @file AddonsManager-SeedFailures.test.ts
+ * @description #951 — page-level seed failures must be loud, and a duplicate
+ * uuid must be caught.
+ *
+ * Two source pages sharing a uuid is the obvious copy-paste mistake when
+ * creating a page from an existing one. Before this the second file matched the
+ * first's already-seeded page and was silently skipped: one page simply never
+ * appeared, and the only trace was a `debug` line phrased as normal operation.
+ */
+vi.unmock('../AddonsManager');
+
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+import matter from 'gray-matter';
+import logger from '../../utils/logger';
+
+const UUID_A = '11111111-2222-3333-4444-555555555555';
+const UUID_B = '66666666-7777-8888-9999-aaaaaaaaaaaa';
+
+describe('#951 addon page seed failures', () => {
+  let tmpDir: string;
+  let pagesDir: string;
+  let manager: { seedAddonPages(name: string, addonPath: string): Promise<void>; addons: Map<string, unknown>; engine: unknown };
+  let warn: ReturnType<typeof vi.spyOn>;
+  let error: ReturnType<typeof vi.spyOn>;
+  let savePage: ReturnType<typeof vi.fn>;
+
+  const writePage = async (file: string, data: Record<string, unknown>) => {
+    await fs.writeFile(path.join(pagesDir, file), matter.stringify('body text', data), 'utf8');
+  };
+
+  const register = (type: 'domain' | 'additive') => {
+    manager.addons.set('demo', { path: tmpDir, module: {}, enabled: true, loaded: true, error: null, manifest: { type } });
+  };
+
+  beforeEach(async () => {
+    tmpDir = path.join(os.tmpdir(), `seed-failures-${Date.now()}-${Math.floor(performance.now())}`);
+    pagesDir = path.join(tmpDir, 'pages');
+    await fs.ensureDir(pagesDir);
+
+    warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    error = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    warn.mockClear();
+    error.mockClear();
+
+    savePage = vi.fn().mockResolvedValue(undefined);
+    const mod = await import('../AddonsManager');
+    const AddonsManager = (mod.default ?? mod) as unknown as { prototype: typeof manager };
+    manager = Object.create(AddonsManager.prototype) as typeof manager;
+    manager.addons = new Map();
+    (manager as { engine: unknown }).engine = {
+      getManager: (n: string) => {
+        if (n === 'PageManager') {
+          return {
+            getPageByUUID: vi.fn().mockResolvedValue(null),
+            pageExists: vi.fn().mockReturnValue(false),
+            getPage: vi.fn().mockResolvedValue(null),
+            savePage
+          };
+        }
+        if (n === 'ConfigurationManager') return { getProperty: (_k: string, d: unknown) => d };
+        if (n === 'NotificationManager') return { createNotification: vi.fn().mockResolvedValue(undefined) };
+        return null;
+      }
+    };
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (await fs.pathExists(tmpDir)) await fs.remove(tmpDir);
+  });
+
+  test('a duplicate uuid is reported, not silently skipped', async () => {
+    register('additive');
+    await writePage('first.md', { uuid: UUID_A, slug: 'first', title: 'First' });
+    await writePage('second.md', { uuid: UUID_A, slug: 'second', title: 'Second' });
+
+    await manager.seedAddonPages('demo', tmpDir);
+
+    const messages = warn.mock.calls.map((c) => String(c[0]));
+    const dup = messages.find((m) => m.includes('already used by'));
+    expect(dup).toBeDefined();
+    expect(dup).toContain(UUID_A);
+    // Names both files so the author can find the collision.
+    expect(dup).toContain('second.md');
+    expect(dup).toContain('first.md');
+  });
+
+  test('the non-duplicate page still seeds — one bad file does not abort the rest', async () => {
+    register('additive');
+    await writePage('first.md', { uuid: UUID_A, slug: 'first', title: 'First' });
+    await writePage('second.md', { uuid: UUID_A, slug: 'second', title: 'Second' });
+    await writePage('third.md', { uuid: UUID_B, slug: 'third', title: 'Third' });
+
+    await manager.seedAddonPages('demo', tmpDir);
+
+    // savePage is keyed by slug.
+    const savedSlugs = savePage.mock.calls.map((c) => c[0]);
+    expect(savedSlugs).toContain('first');
+    expect(savedSlugs).toContain('third');
+    expect(savedSlugs).not.toContain('second');
+  });
+
+  test('a domain addon reports at ERROR — a missing page there is a broken site', async () => {
+    register('domain');
+    await writePage('broken.md', { slug: 'broken', title: 'Broken' }); // no uuid
+
+    await manager.seedAddonPages('demo', tmpDir);
+
+    expect(error).toHaveBeenCalled();
+    expect(String(error.mock.calls[0][0])).toContain('missing or invalid uuid');
+  });
+
+  test('an additive addon reports the same failure at WARN', async () => {
+    register('additive');
+    await writePage('broken.md', { slug: 'broken', title: 'Broken' });
+
+    await manager.seedAddonPages('demo', tmpDir);
+
+    expect(warn).toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  test('an invalid (non-uuid) uuid is caught, not just a missing one', async () => {
+    register('additive');
+    await writePage('bad.md', { uuid: 'not-a-uuid', slug: 'bad', title: 'Bad' });
+
+    await manager.seedAddonPages('demo', tmpDir);
+
+    expect(String(warn.mock.calls[0][0])).toContain('missing or invalid uuid');
+    expect(savePage).not.toHaveBeenCalled();
+  });
+
+  test('seeding does not fail-fast on a malformed page', async () => {
+    // A vendor's typo must not turn into an outage (#951, explicitly rejected
+    // fail-fast). The call resolves normally.
+    register('domain');
+    await writePage('broken.md', { slug: 'broken', title: 'Broken' });
+
+    await expect(manager.seedAddonPages('demo', tmpDir)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #951.

Two defects, one root cause — the seeder’s page-level failures were too quiet.

## 1. Duplicate uuid was undetected

Two source pages sharing a uuid — the obvious copy-paste mistake when creating a page from an existing one — meant the second file matched the first’s already-seeded page and was silently skipped. **One page simply never appeared**, and the only trace was a `debug` line phrased as normal operation. With reseed enabled it is worse: the two files fight over one page and the winner depends on filesystem ordering.

Now caught before seeding, naming both files and the shared uuid.

## 2. Missing/invalid uuid was type-blind

A domain addon’s page failing to seed is a broken site; the same failure in an additive addon is a missing help page. `AddonsManager.ts:~535` already draws exactly that distinction for identity mismatch — `error` for domain, `warn` otherwise. Page seeding now follows it.

## Both now outlive the boot

Each failure raises an operator notification. A boot-time log line is invisible ten minutes later, which is how a page that never seeded stays missing for weeks.

## Still not fail-fast

Per the explicit rejection recorded in #951: refusing to start because a third-party addon shipped one malformed page turns an authoring typo into an outage. The #672 precedent does not transfer — that was the operator’s *own* config naming a nonexistent addon, which the operator can fix. A vendor’s malformed file is not in the operator’s control.

Skip the page, report loudly, surface it after boot. There is a test asserting seeding resolves normally on a malformed page.

## Verification

6 new tests, including the two that matter most: a bad file does not abort the rest of the seed, and domain vs additive really do log at different levels.

Suite 6778 passed, tsc and lint clean.