### PR TITLE
fix(admin): resolve addon page identity from frontmatter uuid, not filename (#964)

### DIFF
--- a/src/routes/WikiRoutes.ts
+++ b/src/routes/WikiRoutes.ts
@@ -3866,6 +3866,37 @@ ${panes}
    * Delete a page
    */
   /**
+   * Resolve an addon page's identity from its source (#964).
+   *
+   * An addon page's identity is its **frontmatter uuid**, never its filename.
+   * Addon sources ship under descriptive, human-reviewable names
+   * (`geohazardwatch-hans.md`) — and per `docs/planning/addons.md` §10 that is
+   * the *correct* convention, because a PR diff and `git log --follow` on a
+   * slug filename are reviewable where a uuid filename is opaque. Only
+   * `required-pages/` is uuid-named, and there the filename genuinely is the
+   * identity.
+   *
+   * Deriving the uuid from an addon filename produced a fake identity like
+   * `"geohazardwatch-hans"`, compared it against `data/pages/geohazardwatch-hans.md`
+   * — a path that never exists — so every such page showed as `new` forever and
+   * a sync wrote a duplicate under the wrong filename.
+   *
+   * Note this is invisible on any instance whose addons all happen to use uuid
+   * filenames, which is why it went unnoticed: the four bundled addons do.
+   *
+   * @param sourceContent - Raw addon page file contents
+   * @returns The frontmatter uuid, or '' when absent or unparseable
+   */
+  static addonSourceUuid(sourceContent: string): string {
+    try {
+      const uuid = matter(sourceContent).data?.uuid;
+      return typeof uuid === 'string' ? uuid.trim() : '';
+    } catch {
+      return '';
+    }
+  }
+
+  /**
    * Log loudly when a permission decision blanks site chrome (#950).
    *
    * `LeftMenu` and `Footer` are fragments rendered into every page, not
@@ -9364,19 +9395,35 @@ ${panes}
           const addonFiles: string[] = (await fse.readdir(pagesDir)).filter((f: string) => f.endsWith('.md'));
 
           for (const file of addonFiles) {
-            const uuid = path.basename(file, '.md');
             const sourcePath = path.join(pagesDir, file);
             const sourceContent: string = await fse.readFile(sourcePath, 'utf8');
 
-            let title = uuid;
+            // #964: an addon page's identity is its FRONTMATTER uuid, never its
+            // filename. Addon sources ship under descriptive, human-reviewable
+            // names (`geohazardwatch-hans.md`) — unlike `required-pages/`, where
+            // the filename genuinely is the uuid. Deriving the uuid from the
+            // filename produced a fake identity like "geohazardwatch-hans" and
+            // then compared against `data/pages/geohazardwatch-hans.md`, a path
+            // that never exists, so every addon page showed as `new` forever and
+            // syncing wrote a duplicate under the wrong filename.
+            let uuid = WikiRoutes.addonSourceUuid(sourceContent);
+            let title = file;
             let slug = '';
             let lastModified = '';
             try {
               const { data } = matter(sourceContent);
-              title = (data.title as string) || uuid;
+              title = (data.title as string) || file;
               slug = (data.slug as string) || '';
               lastModified = (data.lastModified as string) || '';
             } catch { /* use defaults */ }
+            uuid = uuid || '';
+
+            if (!uuid) {
+              // Mandatory and addon-owned (#951). Without it there is nothing to
+              // compare against, so skip rather than invent an identity.
+              logger.warn(`[admin/required-pages] Skipping ${addonName}/pages/${file} — no frontmatter uuid (#964)`);
+              continue;
+            }
             if (!lastModified) {
               try {
                 const stat = await fse.stat(sourcePath);
@@ -9384,7 +9431,9 @@ ${panes}
               } catch { /* leave empty */ }
             }
 
-            const destPath = path.join(pagesDirResolved, file);
+            // The instance store is uuid-named, so the destination is
+            // `<uuid>.md` — not the addon's source filename.
+            const destPath = path.join(pagesDirResolved, `${uuid}.md`);
             let status: 'new' | 'modified' | 'current';
             let userModified = false;
 
@@ -9516,11 +9565,16 @@ ${panes}
         for (const { name: addonName, pagesDir } of addonsManagerPost.getEnabledAddonPagesDirectories()) {
           if (await fse.pathExists(pagesDir)) {
             for (const f of (await fse.readdir(pagesDir))) {
-              if (f.endsWith('.md')) {
-                const u = path.basename(f, '.md');
-                sourceFileMap.set(u, path.join(pagesDir, f));
-                addonSourceUuids.set(u, addonName);
+              if (!f.endsWith('.md')) continue;
+              // #964: key on the frontmatter uuid, not the source filename.
+              const full = path.join(pagesDir, f);
+              const u = WikiRoutes.addonSourceUuid(await fse.readFile(full, 'utf8'));
+              if (!u) {
+                logger.warn(`[admin/required-pages] Skipping ${addonName}/pages/${f} — no frontmatter uuid (#964)`);
+                continue;
               }
+              sourceFileMap.set(u, full);
+              addonSourceUuids.set(u, addonName);
             }
           }
         }

--- a/src/routes/__tests__/WikiRoutes-AddonSourceUuid.test.ts
+++ b/src/routes/__tests__/WikiRoutes-AddonSourceUuid.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @file WikiRoutes-AddonSourceUuid.test.ts
+ * @description #964 — an addon page's identity is its frontmatter uuid, never
+ * its source filename.
+ *
+ * The admin Required Pages Sync tool derived the uuid from the filename. For an
+ * addon shipping `geohazardwatch-hans.md` that produced the fake identity
+ * "geohazardwatch-hans", compared it against `data/pages/geohazardwatch-hans.md`
+ * — a path that never exists — so the page showed as `new` forever and syncing
+ * wrote a duplicate under the wrong filename.
+ *
+ * It went unnoticed because the four bundled addons all use uuid filenames, so
+ * filename and identity happen to coincide there. Per addons.md §10, slug
+ * filenames are the CORRECT convention for addon source, which is exactly the
+ * case that was broken.
+ */
+import matter from 'gray-matter';
+
+const REAL_UUID = '4bf246b9-ebcc-4774-8175-427c275d407c';
+
+const page = (data: Record<string, unknown>) => matter.stringify('page body', data);
+
+describe('#964 addon source uuid resolution', () => {
+  let addonSourceUuid: (s: string) => string;
+
+  beforeEach(async () => {
+    const mod = await import('../WikiRoutes');
+    const WikiRoutes = (mod.default ?? mod) as unknown as { addonSourceUuid(s: string): string };
+    addonSourceUuid = WikiRoutes.addonSourceUuid.bind(WikiRoutes);
+  });
+
+  test('reads the uuid from frontmatter, ignoring the filename entirely', () => {
+    // The slug-named case — the one that was broken.
+    expect(addonSourceUuid(page({ uuid: REAL_UUID, slug: 'us-volcano-alerts-usgs-hans' }))).toBe(REAL_UUID);
+  });
+
+  test('does not confuse the slug for the uuid', () => {
+    const resolved = addonSourceUuid(page({ uuid: REAL_UUID, slug: 'geohazardwatch-hans' }));
+    expect(resolved).toBe(REAL_UUID);
+    expect(resolved).not.toBe('geohazardwatch-hans');
+  });
+
+  test('returns empty when the page has no uuid', () => {
+    // Mandatory and addon-owned (#951); with none there is nothing to compare
+    // against, so the caller skips rather than inventing an identity.
+    expect(addonSourceUuid(page({ slug: 'no-uuid-here', title: 'Orphan' }))).toBe('');
+  });
+
+  test('returns empty for a non-string uuid rather than coercing', () => {
+    expect(addonSourceUuid(page({ uuid: 12345, slug: 'weird' }))).toBe('');
+  });
+
+  test('trims incidental whitespace', () => {
+    expect(addonSourceUuid(`---\nuuid: "  ${REAL_UUID}  "\nslug: x\n---\nbody`)).toBe(REAL_UUID);
+  });
+
+  test('returns empty on unparseable frontmatter instead of throwing', () => {
+    // A malformed vendor file must not take down the admin page.
+    expect(addonSourceUuid('---\nuuid: [unclosed\n---\nbody')).toBe('');
+    expect(addonSourceUuid('no frontmatter at all')).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #964.

## The bug

Required Pages Sync derived an addon page’s uuid from its **source filename**, in both the comparison view and the sync map. For an addon shipping `geohazardwatch-hans.md` that produced the fake identity `"geohazardwatch-hans"`, then compared it against `data/pages/geohazardwatch-hans.md` — a path that never exists.

So the page showed as `new` forever, and applying the sync wrote a **duplicate under the wrong filename** instead of matching the live page.

## Why filenames are not identity

Addon sources ship under descriptive, human-reviewable names, and per `addons.md` §10 that is the **correct** convention — a PR diff and `git log --follow` on a slug filename are reviewable where a uuid filename is opaque.

Only `required-pages/` is uuid-named, and there the filename genuinely *is* the identity. That call site is unchanged.

Pages with no frontmatter uuid are now skipped with a warning rather than given an invented identity.

## Why I cannot show a live before/after

Stated plainly: **the fix is invisible on jimstest.** I measured the admin page with and without it — identical, `0 new / 134 current` both ways.

Every addon installed here uses uuid filenames (all four bundled ones do), so filename and identity coincide and the bug cannot manifest. The addon that would expose it, `geohazardwatch`, is not installed. That is also why this went unnoticed for so long.

So the verification is the unit tests, not a live demonstration. I extracted the resolution into a static `addonSourceUuid()` specifically so the defect is testable without standing up the whole admin route.

## Verification

6 new tests: the slug-named case that was broken, missing and non-string uuids, and malformed frontmatter (which must not take down the admin page).

Suite 6784 passed, tsc and lint clean, admin page loads 200 after rebuild.