### PR TITLE
test(routes): pin agent-token detail onto WikiContext (#949)

### DIFF
--- a/src/routes/__tests__/WikiRoutes-ContextToken.test.ts
+++ b/src/routes/__tests__/WikiRoutes-ContextToken.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @file WikiRoutes-ContextToken.test.ts
+ * @description #949 — a WikiContext must carry the agent-token detail from the
+ * request.
+ *
+ * #946 raised the concern that sites constructing WikiContext directly could
+ * "silently lose the token information: the scope gate would see no scopes and
+ * the save path would stamp no via-token".
+ *
+ * Investigation found only three construction sites, all passing
+ * `req.userContext` and `request: req`, and live audit confirms token-attributed
+ * deletes carry the token id. So the concern does not currently reproduce.
+ *
+ * These tests exist to keep it that way — `viaToken` lives on `req.userContext`,
+ * so anything that rebuilds or synthesises a user context instead of passing the
+ * request's through would silently break attribution. That failure would be
+ * invisible: the request still succeeds, it just stops being traceable to the
+ * token.
+ */
+import WikiRoutes from '../WikiRoutes';
+
+const VIA_TOKEN = { id: 'tok_abc123', name: 'claude-laptop', scopes: ['page-create', 'page-edit'] };
+
+describe('#949 WikiContext preserves agent-token detail', () => {
+  const makeRoutes = () => {
+    const routes = Object.create(WikiRoutes.prototype) as {
+      engine: unknown;
+      createWikiContext(req: unknown, options?: Record<string, unknown>): { userContext?: unknown; request?: unknown };
+    };
+    routes.engine = { getManager: () => null };
+    return routes;
+  };
+
+  const makeReq = (userContext: unknown) => ({
+    userContext,
+    session: {},
+    headers: {},
+    ip: '127.0.0.1'
+  });
+
+  test('viaToken survives onto the context', () => {
+    const req = makeReq({ username: 'agent', isAuthenticated: true, roles: ['editor'], viaToken: VIA_TOKEN });
+
+    const ctx = makeRoutes().createWikiContext(req, { pageName: 'Some Page' });
+
+    expect((ctx.userContext as { viaToken?: unknown })?.viaToken).toEqual(VIA_TOKEN);
+  });
+
+  test('the scopes the ceiling depends on are intact', () => {
+    // The scope gate reads these. If they were lost the token would appear
+    // unrestricted, which is the failure #946 slice 1 actually hit on the live
+    // permission path.
+    const req = makeReq({ username: 'agent', isAuthenticated: true, viaToken: VIA_TOKEN });
+
+    const ctx = makeRoutes().createWikiContext(req, { pageName: 'Some Page' });
+
+    expect((ctx.userContext as { viaToken?: { scopes: string[] } })?.viaToken?.scopes)
+      .toEqual(['page-create', 'page-edit']);
+  });
+
+  test('the original request is attached, not a synthesized one', () => {
+    // Audit reads req.ip and the bearer detail off the real request.
+    const req = makeReq({ username: 'agent', isAuthenticated: true, viaToken: VIA_TOKEN });
+
+    const ctx = makeRoutes().createWikiContext(req, { pageName: 'Some Page' });
+
+    expect(ctx.request).toBe(req);
+  });
+
+  test('a human session is unaffected — no viaToken invented', () => {
+    const req = makeReq({ username: 'jim', isAuthenticated: true, roles: ['admin'] });
+
+    const ctx = makeRoutes().createWikiContext(req, { pageName: 'Some Page' });
+
+    expect((ctx.userContext as { viaToken?: unknown })?.viaToken).toBeUndefined();
+    expect((ctx.userContext as { username?: string })?.username).toBe('jim');
+  });
+
+  test('an anonymous request does not throw', () => {
+    // WikiContext normalises an absent user to null.
+    const ctx = makeRoutes().createWikiContext(makeReq(undefined), { pageName: 'Some Page' });
+    expect(ctx.userContext ?? null).toBeNull();
+  });
+});


### PR DESCRIPTION
For #949.

## The concern did not reproduce

#946 raised that direct `WikiContext` construction "would silently lose the token information: the scope gate would see no scopes and the save path would stamp no via-token", citing three sites.

I investigated rather than assuming:

- There are exactly **three** `new WikiContext(...)` sites in the codebase, all in `WikiRoutes`, and **all three pass `req.userContext` and `request: req`**. Two are the LeftMenu/Footer chrome fragments, which are view-only anyway.
- `viaToken` lives *on* `req.userContext` (set in `app.ts:440`), so forwarding that object carries it automatically.
- Live audit on jimstest confirms it end to end — 12 token-attributed deletes, each recording the token id and `high` severity:

```text
severity: high | token: tok_646f18c073df NGDPBASE-test-946-del | page: NGDPBASE-test-946-delete-...
```

That data reaches the audit only by surviving the `createWikiContext` path.

**So there is no defect to fix, and manufacturing a change would be worse than none.**

## What was actually missing

A guard. `viaToken` riding on `req.userContext` is an implicit contract — anything that rebuilds or synthesises a user context instead of forwarding the request’s would break attribution **silently**. The request still succeeds; it just stops being traceable to the token.

5 tests pin it: `viaToken` survives, its **scopes** survive (the ceiling reads those — the failure slice 1 actually hit on the live permission path), the real request object is attached rather than a synthesized one, a human session gets no invented `viaToken`, and anonymous does not throw.

## Suggested disposition

Close #949 as **verified, not defective** — with the audit evidence above as the record. Reopen if a future path does synthesise a context; the tests will catch it.

Suite 6789 passed.