### PR TITLE
test(e2e): give agent-token specs their own project to stop suite flakiness

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -89,7 +89,7 @@ export default defineConfig({
     // Chromium tests (main browser) - excludes files owned by dedicated viewport projects
     {
       name: 'chromium',
-      testIgnore: /admin-maintenance\.spec\.(js|ts)|mobile-navigation\.spec\.(js|ts)/,
+      testIgnore: /admin-maintenance\.spec\.(js|ts)|mobile-navigation\.spec\.(js|ts)|agent-token-mutations\.spec\.(js|ts)/,
       use: {
         browserName: 'chromium',
         // Use setup project for authenticated tests
@@ -109,8 +109,31 @@ export default defineConfig({
       dependencies: ['setup']
     },
 
+    // Agent-token tests get their own project for the same reason maintenance
+    // does: they cannot share the run with parallel specs.
+    //
+    // Two distinct conflicts, both observed rather than theorised. (1) Every
+    // test mints against the same admin user and the cap is 10 LIVE tokens, so
+    // concurrency exhausts a shared budget. (2) The specs create, delete and
+    // purge pages in a tight loop; page-index writes are serialized through a
+    // write queue, and that churn pushed `pages.spec.ts` page creation and
+    // `search.spec.ts` header search past their timeouts — the full suite went
+    // from consistently green to flaky across three consecutive runs, while the
+    // token spec passed 7/7 in isolation every time.
+    {
+      name: 'chromium-agent-tokens',
+      testMatch: /agent-token-mutations\.spec\.(js|ts)/,
+      use: {
+        browserName: 'chromium',
+        storageState: './tests/e2e/.auth/user.json'
+      },
+      dependencies: ['chromium']
+    },
+
     // Admin maintenance tests run LAST since they toggle server-wide maintenance mode
-    // which would cause other parallel tests to get 503 responses
+    // which would cause other parallel tests to get 503 responses — including the
+    // agent-token project above, hence the chain rather than both depending on
+    // 'chromium' and racing each other.
     {
       name: 'chromium-maintenance',
       testMatch: /admin-maintenance\.spec\.(js|ts)/,
@@ -118,7 +141,7 @@ export default defineConfig({
         browserName: 'chromium',
         storageState: './tests/e2e/.auth/user.json'
       },
-      dependencies: ['chromium']
+      dependencies: ['chromium-agent-tokens']
     }
   ],
 


### PR DESCRIPTION
The #946 slice-2 specs made the full E2E suite flaky. **Caught by the release gate, not by the run that shipped them** — they were verified in isolation, where they pass 7/7 every time.

Three consecutive full runs, three different victims:

```text
run 1: pages.spec.ts   "should create a new wiki page"   (timeout)
run 2: search.spec.ts  "should search from header"       (timeout)
       agent-token     "a token scoped to rename"        (timeout)
run 3: pages.spec.ts   "should create a new wiki page"   (flaky, passed on retry)
```

## Two conflicts, both observed

1. Every test mints against the **same admin user**, and the cap is 10 *live* tokens — concurrency turns that into a contended budget.
2. The specs create, delete and purge pages in a tight loop. Page-index writes are serialized through a write queue, and that churn pushed other specs past their 30s timeouts.

## The fix follows existing precedent

`chromium-maintenance` already has its own project precisely because it cannot share a run with parallel specs. Same treatment here.

The maintenance project now chains **after** the token project rather than both depending on `chromium` and racing — maintenance toggles server-wide maintenance mode, which would 503 the token tests.

## Verification

Three consecutive full runs: **86 passed, 0 flaky**, where the same suite failed or went flaky on all three runs before.