### PR TITLE
test(e2e): make the agent-token probe a mutating request

### DIFF
--- a/tests/e2e/agent-token-mutations.spec.ts
+++ b/tests/e2e/agent-token-mutations.spec.ts
@@ -47,11 +47,26 @@ async function tokensUsable(request): Promise<boolean> {
     const body = await res.json().catch(() => ({}));
     if (!body.success) return false;
 
-    // A GET is enough: it proves the bearer middleware authenticated the token.
-    const probe = await request.get('/api/tokens', {
-      headers: { Authorization: `Bearer ${body.token}`, Accept: 'application/json' }
+    // The probe MUST be a mutating request. A GET proves nothing: CSRF skips
+    // safe methods outright, so a bearer GET returns 200 even when the bearer
+    // middleware never authenticated the token — which is exactly how the
+    // previous probe reported "usable" on an instance where it was not.
+    //
+    // A bearer POST with no CSRF header is the real question: it succeeds only
+    // when `req.bearerAuth` was set, and answers 403 "invalid CSRF token" when
+    // it was not (#981).
+    const probe = await request.post('/api/tokens', {
+      headers: { Authorization: `Bearer ${body.token}`, 'Content-Type': 'application/json' },
+      data: { name: `${PREFIX}-probe2`, scopes: ['page-read'], ttlHours: 1 }
     });
-    const ok = probe.status() === 200;
+    // 403 means CSRF rejected it, i.e. bearer auth did not happen. Any other
+    // answer (201 mint, or a 4xx from the route's own rules) means it did.
+    const ok = probe.status() !== 403;
+
+    const probeBody = await probe.json().catch(() => ({}));
+    if (probeBody?.record?.id) {
+      await request.delete(`/api/tokens/${probeBody.record.id}`, { headers: await sessionHeaders(request) }).catch(() => {});
+    }
 
     await request.delete(`/api/tokens/${body.record?.id}`, { headers: await sessionHeaders(request) }).catch(() => {});
     return ok;


### PR DESCRIPTION
Third correction to the same guard. Worth stating why, because the pattern matters more than the fix.

## Why the last probe was vacuous

It used a bearer **GET**. CSRF skips safe methods outright, so a bearer GET returns 200 even when the middleware never authenticated the token. It reported "usable" on The Fairways, where tokens are not usable, and the suite failed there for a third propagation cycle.

## The fix

Probe with a bearer **POST** and no CSRF header. That succeeds only when `req.bearerAuth` was set, and answers 403 `invalid CSRF token` when it was not (#981). Any non-403 answer — a 201 mint, or a 4xx from the route’s own rules — means bearer auth happened, which is the only thing this suite needs to know.

The probe cleans up whatever it mints.

## The pattern in all three attempts

I asserted what the environment would do instead of asking it:

1. Guessed the disabled-state status codes (404/501) — it answers 403.
2. Probed the wrong endpoint — mint/list work even when auth cannot.
3. Used a method that made the check vacuous — CSRF never applies to GET.

Each one passed on jimstest and failed on the second instance. The single-instance run kept confirming a guard that did not hold anywhere else.

## Verification

55 passed on jimstest. Fairways revalidation follows this merge.