### PR TITLE
test(e2e): only assert delete recoverability where soft delete exists

### DIFF
--- a/tests/e2e/agent-token-mutations.spec.ts
+++ b/tests/e2e/agent-token-mutations.spec.ts
@@ -143,7 +143,9 @@ test.describe('#946 slice 2 — agent token page mutations', () => {
     }
 
     // Purge the #947 tombstones so test pages leave no storage behind.
-    const trash = await (await request.get('/api/admin/deleted-pages')).json().catch(() => ({ pages: [] }));
+    // Same tolerance here: no soft delete means no tombstones to purge.
+    const trashRes = await request.get('/api/admin/deleted-pages').catch(() => null);
+    const trash = trashRes?.status() === 200 ? await trashRes.json().catch(() => ({})) : {};
     for (const entry of (trash.pages || []).filter((p) => String(p.title).startsWith(PREFIX))) {
       await request.delete(`/api/admin/deleted-pages/${entry.uuid}`, { headers }).catch(() => {});
     }
@@ -164,9 +166,16 @@ test.describe('#946 slice 2 — agent token page mutations', () => {
 
     expect((await request.get(`/view/${encodeURIComponent(title)}`)).status()).toBe(404);
 
-    // #947: it must be in the trash, not destroyed.
-    const trash = await (await request.get('/api/admin/deleted-pages')).json();
-    expect(trash.pages.find((p) => p.title === title)).toBeTruthy();
+    // #947: where soft delete is available, the page must be in the trash rather
+    // than destroyed. Not every instance has it — a provider without soft delete
+    // answers 501, and the temp build does exactly that. Assert recoverability
+    // only where recoverability exists, instead of indexing a `pages` array that
+    // is not there.
+    const trashRes = await request.get('/api/admin/deleted-pages');
+    if (trashRes.status() === 200) {
+      const trash = await trashRes.json();
+      expect((trash.pages || []).find((p) => p.title === title)).toBeTruthy();
+    }
   });
 
   test('a token WITHOUT page-delete is refused (scope ceiling holds on the real path)', async ({ request }) => {


### PR DESCRIPTION
The delete test asserted the page lands in the trash **unconditionally**. Soft delete (#947) is a provider capability, not a guarantee — a provider without it answers 501 `Soft delete not supported`, and the temp build does exactly that. The test then indexed `trash.pages` on an error body and died with `Cannot read properties of undefined`.

Now it asserts recoverability only where recoverability exists. The core of the test — the token-authenticated delete succeeds and the page stops resolving — still runs everywhere, which is the part actually about #946.

## Worth flagging separately

**Deletes on the temp build are still hard deletes.** #947 shipped in the platform, but that instance’s page provider does not expose the soft-delete surface, so version history there is still destroyed on delete. That may be intentional for a throwaway sandbox, or it may mean the provider config differs from what #947 assumed. Flagging rather than changing it.

## Verification

55 passed on jimstest; propagation to both satellites follows.