### PR TITLE
fix(auth): gate agent-token routes on the enabled flag, and reject bad tokens as 401 (#981)

### DIFF
--- a/docs/providers/BasePageProvider.md
+++ b/docs/providers/BasePageProvider.md
@@ -25,7 +25,7 @@ Per the architecture: managers are agnostic to the filesystem; providers carry t
 | `getPageContent(identifier)` | Just the markdown body |
 | `getPageMetadata(identifier)` | Just the frontmatter |
 | `savePage(name, content, metadata, options?)` | Persist |
-| `deletePage(identifier)` | Remove |
+| `deletePage(identifier, deletedBy?)` | Remove — **hard or soft depending on the provider**, see below |
 | `pageExists(identifier)` | Boolean check |
 | `getAllPages()` / `getAllPageInfo(opts?)` | Enumerate |
 | `findPage(identifier)` | Resolve UUID / title / slug |
@@ -44,6 +44,59 @@ Providers that support versioning override:
 - `purgeOldVersions(identifier, options?)`
 
 Non-versioning providers leave these as the abstract default (which throws).
+
+## Delete Semantics — provider-dependent (#947, #981)
+
+**A delete is not the same operation on every provider, and callers must not assume it is recoverable.**
+
+| Provider | `deletePage()` behaviour | Recoverable? |
+|---|---|---|
+| `FileSystemProvider` | **Hard delete** — unlinks the file, drops it from the caches | No |
+| `VersioningFileProvider` | **Soft delete** — moves the file to `<location>/deleted/`, keeps the whole version directory, moves the index entry to a tombstone | Yes, for the retention window |
+
+This follows directly from what each provider is: soft delete exists to preserve
+version history, and a provider with no versions has none to preserve. There is
+nothing to fix here — `FileSystemProvider` deleting outright is correct for what
+it is. What matters is that **nothing downstream may assume otherwise.**
+
+### Detecting the capability
+
+The soft-delete surface is optional, exactly like the versioning surface above:
+
+- `getDeletedPages()`
+- `restoreDeletedPage(uuid)`
+- `purgeDeletedPage(uuid)`
+- `purgeExpiredDeletedPages()`
+
+A provider without them has no trash. The admin trash API answers **501
+`Soft delete not supported`** rather than pretending, so the right capability
+check is the response status — not the presence of a delete route, and not an
+assumption carried over from another instance.
+
+```js
+const res = await fetch('/api/admin/deleted-pages');
+if (res.status === 501) {
+  // No trash on this instance. Deletes here are permanent.
+}
+```
+
+### Why this bites
+
+Instances in the same fleet can differ. During the v3.70.0 release the E2E
+suite asserted that a deleted page lands in the trash — true on the instances
+running `VersioningFileProvider`, false on the temp build, which runs a
+provider with no versions. The test had passed for two releases because it only
+ever ran where the assumption happened to hold.
+
+The same class of mistake produced #981: a capability that is configuration- or
+provider-dependent was treated as universal, and the resulting failure surfaced
+as something unrelated.
+
+### Retention
+
+Where soft delete IS available, `ngdpbase.page.delete.retentiondays` (default
+`30`, `0` = keep forever) governs when a tombstoned page and its versions are
+purged for good. Purge runs at boot and hourly.
 
 ## See Also
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -393,7 +393,7 @@ void (async (): Promise<void> => {
   // in-app agent-token provider and Authentik coexist (or run alone, or
   // neither).
   const BEARER_PROVIDER_IDS = ['authentik-bearer', 'agent-token'];
-  app.use(async (req: Request, _res: Response, next: NextFunction) => {
+  app.use(async (req: Request, res: Response, next: NextFunction) => {
     try {
       const header = req.headers['authorization'];
       if (!header || typeof header !== 'string' || !header.startsWith('Bearer ')) { next(); return; }
@@ -407,8 +407,34 @@ void (async (): Promise<void> => {
       } | null;
       const registered = new Set((authManager?.getProviders?.() ?? []).map(p => p.id));
       const candidates = BEARER_PROVIDER_IDS.filter(id => registered.has(id));
-      if (!authManager?.authenticate || candidates.length === 0) { next(); return; }
       const token = header.slice('Bearer '.length).trim();
+
+      // #981: an ngdp_at_ token is unambiguously an agent token. If it cannot
+      // be authenticated — feature disabled, provider unregistered, token
+      // revoked or expired — say THAT, rather than falling through to the CSRF
+      // guard and answering `Forbidden — invalid CSRF token`. The old
+      // behaviour sent operators debugging CSRF configuration over a token
+      // problem, which is about as misleading as an error can be.
+      const looksLikeAgentToken = token.startsWith('ngdp_at_');
+      const rejectAgentToken = (reason: string): void => {
+        logger.warn(`[bearer] rejected agent token — ${reason}`);
+        res.status(401).json({
+          success: false,
+          error: 'Invalid or unusable agent token',
+          message: reason
+        });
+      };
+
+      if (!authManager?.authenticate || candidates.length === 0) {
+        if (looksLikeAgentToken) {
+          rejectAgentToken(
+            'agent tokens are not enabled on this instance (ngdpbase.auth.agent-token.enabled)'
+          );
+          return;
+        }
+        next();
+        return;
+      }
       if (!token) { next(); return; }
 
       let result: { success: boolean; username?: string; viaToken?: { id: string; name: string; scopes: string[] } } = { success: false };
@@ -442,6 +468,13 @@ void (async (): Promise<void> => {
           (req as Request & { bearerAuth?: boolean }).bearerAuth = true;
           logger.info(`[bearer:${matchedProvider}] Authenticated API request as: ${result.username}`);
         }
+      }
+
+      // #981: same reasoning as above, for a token that reached a registered
+      // provider and was still refused.
+      if (!(req as Request & { bearerAuth?: boolean }).bearerAuth && looksLikeAgentToken) {
+        rejectAgentToken('token is invalid, revoked, expired, or its owner is inactive');
+        return;
       }
     } catch (err) {
       logger.warn('[bearer middleware] failed:', err);

--- a/src/routes/WikiRoutes.ts
+++ b/src/routes/WikiRoutes.ts
@@ -3866,6 +3866,30 @@ ${panes}
    * Delete a page
    */
   /**
+   * Whether agent tokens are usable on this instance (#981).
+   *
+   * Must be the SAME condition `AuthManager` uses to register the
+   * `agent-token` provider, because a token that cannot authenticate must not
+   * be issuable. `AgentTokenManager` is registered unconditionally in
+   * `WikiEngine`, so checking only for the manager — which is what the mint
+   * route used to do — reports "available" on every instance, including the
+   * ones where the provider was never registered.
+   *
+   * The result on a default (disabled) instance was a token that mints with a
+   * 201, is stored, is shown once with "copy this now", and can never be used.
+   * Worse, using it failed as `Forbidden — invalid CSRF token`, because the
+   * bearer middleware never set `req.bearerAuth` and the request fell through
+   * to the CSRF guard — pointing the operator at entirely the wrong subsystem.
+   */
+  private agentTokensEnabled(): boolean {
+    return Boolean(
+      this.engine.getManager('AgentTokenManager') &&
+      this.engine.getManager<{ getProperty(k: string, d: unknown): unknown }>('ConfigurationManager')
+        ?.getProperty('ngdpbase.auth.agent-token.enabled', false)
+    );
+  }
+
+  /**
    * Resolve an addon page's identity from its source (#964).
    *
    * An addon page's identity is its **frontmatter uuid**, never its filename.
@@ -6949,7 +6973,9 @@ ${panes}
       if (!user?.isAuthenticated || !user.username) {
         return res.status(401).json({ success: false, error: 'Authentication required' });
       }
-      const manager = this.engine.getManager('AgentTokenManager') as import('../managers/AgentTokenManager.js').default | null;
+      const manager = this.agentTokensEnabled()
+        ? this.engine.getManager('AgentTokenManager') as import('../managers/AgentTokenManager.js').default | null
+        : null;
       if (!manager) {
         return res.status(503).json({ success: false, error: 'Agent tokens are not enabled' });
       }
@@ -6983,7 +7009,9 @@ ${panes}
       if (!user?.isAuthenticated || !user.username) {
         return res.status(401).json({ success: false, error: 'Authentication required' });
       }
-      const manager = this.engine.getManager('AgentTokenManager') as import('../managers/AgentTokenManager.js').default | null;
+      const manager = this.agentTokensEnabled()
+        ? this.engine.getManager('AgentTokenManager') as import('../managers/AgentTokenManager.js').default | null
+        : null;
       if (!manager) {
         return res.status(503).json({ success: false, error: 'Agent tokens are not enabled' });
       }
@@ -7032,7 +7060,9 @@ ${panes}
       if (!user?.isAuthenticated || !user.username) {
         return res.status(401).json({ success: false, error: 'Authentication required' });
       }
-      const manager = this.engine.getManager('AgentTokenManager') as import('../managers/AgentTokenManager.js').default | null;
+      const manager = this.agentTokensEnabled()
+        ? this.engine.getManager('AgentTokenManager') as import('../managers/AgentTokenManager.js').default | null
+        : null;
       if (!manager) {
         return res.status(503).json({ success: false, error: 'Agent tokens are not enabled' });
       }

--- a/src/routes/__tests__/WikiRoutes-AgentTokenGate.test.ts
+++ b/src/routes/__tests__/WikiRoutes-AgentTokenGate.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @file WikiRoutes-AgentTokenGate.test.ts
+ * @description #981 — a token that cannot authenticate must not be issuable.
+ *
+ * `AgentTokenManager` is registered unconditionally by `WikiEngine`, but
+ * `AuthManager` only registers the `agent-token` auth provider when
+ * `ngdpbase.auth.agent-token.enabled` is true. The mint route checked only for
+ * the manager, so on a default (disabled) instance it happily minted tokens
+ * that could never authenticate — and using one failed as
+ * "Forbidden — invalid CSRF token", pointing at the wrong subsystem entirely.
+ */
+import WikiRoutes from '../WikiRoutes';
+
+type Gated = { engine: unknown; agentTokensEnabled(): boolean };
+
+const makeRoutes = (opts: { manager?: boolean; enabled?: unknown }) => {
+  const routes = Object.create(WikiRoutes.prototype) as Gated;
+  routes.engine = {
+    getManager: (n: string) => {
+      if (n === 'AgentTokenManager') return opts.manager === false ? null : { mint: () => {} };
+      if (n === 'ConfigurationManager') return { getProperty: () => opts.enabled };
+      return null;
+    }
+  };
+  return routes;
+};
+
+describe('#981 agent token enablement gate', () => {
+  test('enabled only when BOTH the manager exists and config says so', () => {
+    expect(makeRoutes({ manager: true, enabled: true }).agentTokensEnabled()).toBe(true);
+  });
+
+  test('disabled when the config flag is false, even though the manager exists', () => {
+    // The exact production shape: WikiEngine always registers the manager, so
+    // this is the default state of every instance that has not opted in.
+    expect(makeRoutes({ manager: true, enabled: false }).agentTokensEnabled()).toBe(false);
+  });
+
+  test('disabled when the config flag is absent', () => {
+    expect(makeRoutes({ manager: true, enabled: undefined }).agentTokensEnabled()).toBe(false);
+  });
+
+  test('disabled when the manager is missing', () => {
+    expect(makeRoutes({ manager: false, enabled: true }).agentTokensEnabled()).toBe(false);
+  });
+
+  test('matches the condition AuthManager uses to register the provider', () => {
+    // The whole point: these two gates must agree. If AuthManager registers on
+    // `enabled` and the routes gate on anything else, an instance can mint
+    // credentials that its own middleware will refuse.
+    for (const enabled of [true, false]) {
+      expect(makeRoutes({ manager: true, enabled }).agentTokensEnabled()).toBe(enabled);
+    }
+  });
+});


### PR DESCRIPTION
Closes #981. Also documents the provider-dependent delete semantics noted in #984.

## Token generation was not gated by configuration

The profile UI card **was** gated on `ngdpbase.auth.agent-token.enabled`. The API was not — mint checked only `getManager('AgentTokenManager')`, and `WikiEngine` registers that unconditionally.

So the gate was cosmetic: hidden button, open endpoint.

Meanwhile `AuthManager` registers the auth **provider** only when the flag is true. Two gates that had to agree, didn't. On a default (disabled) instance an admin could mint a token that returned 201, was stored, was shown once with "copy this now" — and could never authenticate.

## The failure mode was the worst part

With no provider registered, the bearer middleware never set `req.bearerAuth`, so the request fell through to the CSRF guard:

```text
Forbidden — invalid CSRF token
```

Nothing there points at "the feature is off". Debugging it means reading CSRF configuration over what is actually a token problem.

## Two changes

1. **All three token routes** (mint, list, revoke) gate on the same condition `AuthManager` uses. A token that cannot authenticate is no longer issuable — 503 `Agent tokens are not enabled`.
2. **A bearer credential with the `ngdp_at_` prefix** that cannot be authenticated gets 401 with the reason, instead of falling through to CSRF. The prefix makes it unambiguous, so this cannot swallow an Authentik bearer or a session request. Covers both "disabled" and "revoked / expired / owner inactive".

## Verified where it actually broke

On The Fairways (feature disabled):

```text
MINT          -> 503 {"error":"Agent tokens are not enabled"}
LIST          -> 503 {"error":"Agent tokens are not enabled"}
BEARER DELETE -> 401 {"error":"Invalid or unusable agent token",
                      "message":"agent tokens are not enabled on this instance
                                 (ngdpbase.auth.agent-token.enabled)"}
```

## Documentation

`BasePageProvider.md` now covers delete semantics. Soft delete (#947) is a `VersioningFileProvider` capability — `FileSystemProvider` has no versions to preserve, so it hard-deletes. **Correct for what it is**, but callers must not assume recoverability; the trash API answers 501 where there is no trash, and that status is the capability check.

That is the same class of mistake as #981: treating a provider- or config-dependent capability as universal.

## Verification

5 gate tests including that it matches `AuthManager` exactly. Suite 6794 passed, 86 E2E.