### PR TITLE
feat(addons): stamp frontmatter access on seeded pages (#971, addons.md §3)

### DIFF
--- a/src/managers/AddonsManager.ts
+++ b/src/managers/AddonsManager.ts
@@ -670,6 +670,40 @@ class AddonsManager extends BaseManager {
    * @param addonPath  Filesystem path to the add-on directory
    */
   /**
+   * Default edit-protection for a seeded addon page (#971, addons.md §3).
+   *
+   * §3 settled the mechanism: the seeder stamps frontmatter `access`, which
+   * Tier 1 of the evaluator honours directly, needs no `PolicyEvaluator`
+   * change, and is hash-neutral (`pageSourceHash` covers the body only, so
+   * adding metadata cannot disturb the #920 reseed comparison).
+   *
+   * §9 settled *who owns what*, and the two must be read together. A blanket
+   * admin lock would contradict the operator's decision that domain content
+   * pages "should be normal pages, purely seeded by the addon" — the addon
+   * provides a starting corpus and then lets go. So the default follows §9's
+   * ownership column rather than locking everything:
+   *
+   * | Category | Purpose | Default |
+   * |---|---|---|
+   * | `system` | Feature UI, site chrome — infrastructure | admin-only edit |
+   * | `documentation` | Help / docs — addon-owned | admin-only edit |
+   * | `general` | Domain content, demo — **instance-owned** | no stamp |
+   * | anything else | unclassified, treated as addon-owned | admin-only edit |
+   *
+   * An addon can always override by declaring its own `access`, which is the
+   * documented escape hatch in §3 and the reason the default is a default.
+   *
+   * @param category - The page's resolved `system-category`
+   * @returns The access object to stamp, or undefined to leave the page unprotected
+   */
+  private defaultAddonPageAccess(category: unknown): { edit: string[] } | undefined {
+    // Instance-owned per §9 — seeded as a starting point, then editable by
+    // whoever normally edits pages on this site.
+    if (category === 'general') return undefined;
+    return { edit: ['admin'] };
+  }
+
+  /**
    * Surface a page-level seed failure beyond the boot log (#951).
    *
    * A boot-time log line is invisible ten minutes later, which is how a page
@@ -827,11 +861,22 @@ class AddonsManager extends BaseManager {
             // fields, adopt the source body, keep the UUID, stamp the hash. Goes
             // through savePage so the versioning provider records a revertable
             // version.
+            const reseedCategory = (parsed.data as Record<string, unknown>)['system-category']
+              ?? existingMeta['system-category'] ?? 'addon';
+            // #971: source first, then whatever the page already carries — an
+            // operator who deliberately opened a page up must not have that
+            // reverted by a routine reseed. Only a page with no `access` at all
+            // (seeded before this existed) picks up the default.
+            const reseedAccess = (parsed.data as Record<string, unknown>)['access']
+              ?? existingMeta['access']
+              ?? this.defaultAddonPageAccess(reseedCategory);
+
             const reseedMetadata: Record<string, unknown> = {
               ...existingMeta,
               ...(parsed.data as Record<string, unknown>),
               addon: addonName,
-              'system-category': (parsed.data as Record<string, unknown>)['system-category'] ?? existingMeta['system-category'] ?? 'addon',
+              'system-category': reseedCategory,
+              ...(reseedAccess ? { access: reseedAccess } : {}),
               'addon-source-hash': srcHash
             };
             await pageManager.savePage(existingSlug, parsed.content, reseedMetadata);
@@ -863,10 +908,17 @@ class AddonsManager extends BaseManager {
         // Seed through PageManager so all page providers (including VersioningFileProvider)
         // update their index correctly. `addon-source-hash` stamps the seeded
         // content so a later reseed can tell an unmodified page from an edited one.
+        const seedCategory = (parsed.data as Record<string, unknown>)['system-category'] ?? 'addon';
+        // #971: stamp `access` only when the source is silent, so an addon can
+        // ship a deliberately community-editable page.
+        const seedAccess = (parsed.data as Record<string, unknown>)['access']
+          ?? this.defaultAddonPageAccess(seedCategory);
+
         const metadata: Record<string, unknown> = {
           ...(parsed.data as Record<string, unknown>),
           addon: addonName,
-          'system-category': (parsed.data as Record<string, unknown>)['system-category'] ?? 'addon',
+          'system-category': seedCategory,
+          ...(seedAccess ? { access: seedAccess } : {}),
           'addon-source-hash': pageSourceHash(parsed.content)
         };
 

--- a/src/managers/__tests__/AddonsManager-AccessStamp.test.ts
+++ b/src/managers/__tests__/AddonsManager-AccessStamp.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @file AddonsManager-AccessStamp.test.ts
+ * @description #971 — the seeder stamps frontmatter `access` so addon pages are
+ * admin-editable only (addons.md §3), with the default following §9's ownership
+ * column rather than locking everything.
+ */
+vi.unmock('../AddonsManager');
+
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+import matter from 'gray-matter';
+
+const UUID = (n: number) => `${String(n).repeat(8)}-2222-3333-4444-555555555555`;
+
+describe('#971 addon page access stamping', () => {
+  let tmpDir: string;
+  let pagesDir: string;
+  let savePage: ReturnType<typeof vi.fn>;
+  let manager: { seedAddonPages(n: string, p: string): Promise<void>; addons: Map<string, unknown>; engine: unknown };
+
+  const write = async (file: string, data: Record<string, unknown>) => {
+    await fs.writeFile(path.join(pagesDir, file), matter.stringify('body', data), 'utf8');
+  };
+
+  /** Metadata the seeder passed to savePage for a given slug. */
+  const metaFor = (slug: string) =>
+    savePage.mock.calls.find((c) => c[0] === slug)?.[2] as Record<string, unknown> | undefined;
+
+  beforeEach(async () => {
+    tmpDir = path.join(os.tmpdir(), `access-stamp-${Date.now()}-${Math.floor(performance.now())}`);
+    pagesDir = path.join(tmpDir, 'pages');
+    await fs.ensureDir(pagesDir);
+    savePage = vi.fn().mockResolvedValue(undefined);
+
+    const mod = await import('../AddonsManager');
+    const AddonsManager = (mod.default ?? mod) as unknown as { prototype: typeof manager };
+    manager = Object.create(AddonsManager.prototype) as typeof manager;
+    manager.addons = new Map([['demo', { path: tmpDir, module: {}, enabled: true, loaded: true, error: null, manifest: { type: 'domain' } }]]);
+    (manager as { engine: unknown }).engine = {
+      getManager: (n: string) => {
+        if (n === 'PageManager') {
+          return {
+            getPageByUUID: vi.fn().mockResolvedValue(null),
+            pageExists: vi.fn().mockReturnValue(false),
+            getPage: vi.fn().mockResolvedValue(null),
+            savePage
+          };
+        }
+        if (n === 'ConfigurationManager') return { getProperty: (_k: string, d: unknown) => d };
+        return null;
+      }
+    };
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (await fs.pathExists(tmpDir)) await fs.remove(tmpDir);
+  });
+
+  test('a system page (feature UI, site chrome) is admin-edit only', async () => {
+    await write('a.md', { uuid: UUID(1), slug: 'left-menu-content', 'system-category': 'system' });
+    await manager.seedAddonPages('demo', tmpDir);
+    expect(metaFor('left-menu-content')?.access).toEqual({ edit: ['admin'] });
+  });
+
+  test('a documentation page is admin-edit only', async () => {
+    await write('a.md', { uuid: UUID(2), slug: 'calendarhelp', 'system-category': 'documentation' });
+    await manager.seedAddonPages('demo', tmpDir);
+    expect(metaFor('calendarhelp')?.access).toEqual({ edit: ['admin'] });
+  });
+
+  test('a general page is NOT locked — domain content is instance-owned (§9)', async () => {
+    // The decision this must honour: "Domain Content pages should be normal
+    // pages, purely seeded by addon." Locking them would contradict it.
+    await write('a.md', { uuid: UUID(3), slug: 'earthquakes', 'system-category': 'general' });
+    await manager.seedAddonPages('demo', tmpDir);
+    expect(metaFor('earthquakes')?.access).toBeUndefined();
+  });
+
+  test('an unclassified page defaults to addon-owned, so it is locked', async () => {
+    await write('a.md', { uuid: UUID(4), slug: 'mystery' });
+    await manager.seedAddonPages('demo', tmpDir);
+    expect(metaFor('mystery')?.access).toEqual({ edit: ['admin'] });
+  });
+
+  test("a source-declared access always wins — the addon's documented escape hatch", async () => {
+    await write('a.md', {
+      uuid: UUID(5), slug: 'community', 'system-category': 'documentation',
+      access: { edit: ['contributor'] }
+    });
+    await manager.seedAddonPages('demo', tmpDir);
+    expect(metaFor('community')?.access).toEqual({ edit: ['contributor'] });
+  });
+
+  test('stamping access does not disturb the reseed hash (#920)', async () => {
+    // pageSourceHash covers the BODY only. If access stamping changed it, every
+    // page would read as locally-modified and reseed would stop permanently.
+    await write('a.md', { uuid: UUID(6), slug: 'hashcheck', 'system-category': 'system' });
+    await manager.seedAddonPages('demo', tmpDir);
+
+    const meta = metaFor('hashcheck');
+    expect(meta.access).toEqual({ edit: ['admin'] });
+    expect(typeof meta['addon-source-hash']).toBe('string');
+
+    // Assert against the real function rather than a hand-rolled hash: the
+    // point is that the stamp equals the hash of the BODY ALONE, unaffected by
+    // any metadata the seeder added.
+    const { pageSourceHash } = await import('../../utils/addonPageSync');
+    expect(meta['addon-source-hash']).toBe(pageSourceHash('body'));
+  });
+
+  test('view is left alone so pages stay publicly readable', async () => {
+    await write('a.md', { uuid: UUID(7), slug: 'readable', 'system-category': 'system' });
+    await manager.seedAddonPages('demo', tmpDir);
+    const access = metaFor('readable')?.access as Record<string, unknown>;
+    expect(access.edit).toEqual(['admin']);
+    expect(access.view).toBeUndefined();
+  });
+});


### PR DESCRIPTION
For #971. Unblocks §3 compliance for every addon — jwilleke/geohazardwatch#177 and #972 were both waiting on this.

## What was missing

§3 settled the mechanism for admin-only editing of addon pages, and was explicitly reinstated on 2026-07-26 after the #945 detour. **It was never implemented.** `AddonsManager` stamped `addon`, `system-category` and `addon-source-hash`, and had no `access` handling at all.

The seeder now stamps frontmatter `access` on seed and reseed.

## Why frontmatter, verified rather than assumed

§3 argues frontmatter needs no evaluator change. I checked instead of trusting it — `ACLManager.checkFrontmatterAccess` reads `metadata.access[action]` as a principal list, matches against roles or username, denies otherwise. It works, and it is hash-neutral because `pageSourceHash` covers the body only.

I also confirmed `admin` is the exact role name in `ngdpbase.roles.definitions` (`admin`, `user-admin`, `editor`, `contributor`, `reader`, `member`, `anonymous`). A mismatch there would have locked every stamped page for *everyone, including admins* — a silent, total lockout.

## The default is not a blanket lock

§3 and §9 have to be read together, and a naive reading of §3 alone contradicts §9.

§9 settled that domain content pages **"should be normal pages, purely seeded by addon"** — the addon provides a starting corpus and then lets go. Admin-locking those would contradict that decision outright, and would have made most of geohazardwatch's content admin-only.

So the default follows §9's ownership column:

| Category | Purpose | Default |
|---|---|---|
| `system` | Feature UI, site chrome | admin-only edit |
| `documentation` | Help / docs | admin-only edit |
| `general` | Domain content, demo — **instance-owned** | no stamp |
| unclassified | treated as addon-owned | admin-only edit |

Only `edit` is stamped — `view` falls through, so pages stay publicly readable. A source-declared `access` always wins, which is §3's documented escape hatch.

On **reseed** the order is source → whatever the page already carries → default. An operator who deliberately opened a page up does not get that reverted by a routine reseed.

## What this does NOT do

**Existing seeded pages are unaffected.** Reseed is opt-in and off by default, so the 8 addon pages on jimstest still carry no `access` — I checked on disk rather than assuming:

```text
UpcomingEvents       cat=addon  access=False
CalendarHelp         cat=addon  access=False
My Journal           cat=addon  access=False
… 5 more, all False
```

The backfill for legacy pages that §2 calls for is still outstanding, so **#971 should stay open** for it rather than being closed by this PR.

Note those pages all sit at `system-category: addon` — the flattened default §9 identified. Once addons re-categorise per the taxonomy (geohazardwatch#177 step 1), the stamping above starts landing meaningfully.

## Verification

7 tests: each category branch, the source override, `view` left alone, and that the stamp does not disturb the #920 reseed hash — asserted against the real `pageSourceHash` rather than a hand-rolled one.

Suite **6801 passed**, `tsc` and lint clean.
