### PR TITLE
fix(docker): remove npm from the runtime image (#956)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,12 +51,33 @@ WORKDIR /app
 # Note: g++ is needed at runtime for node-gyp if bcrypt needs recompilation
 RUN apk add --no-cache libstdc++
 
-# Replace the base image's npm with a current major (#859): the npm CLI bundled
-# with the Node image ships stale copies of tar/minimatch/glob/undici under
-# /usr/local/lib/node_modules/npm that Trivy flags on every scan. The app never
-# runs npm at runtime, but the files ship in the image either way — keep them
-# patched. npm@12 pins the major; each build picks up the latest 12.x patches.
-RUN npm install -g npm@12 && npm cache clean --force
+# Remove npm and npx from the runtime image entirely (#956).
+#
+# #859 replaced the base image's npm with npm@12 so its bundled dependencies
+# would be current. That stopped working as a strategy: npm@12.0.1 — the latest
+# release — still bundles `tar 7.5.19` and `brace-expansion 5.0.7`, each exactly
+# one patch below the fix (7.5.21 and 5.0.8). Chasing npm's bundle lag means
+# living with whatever CVEs its vendored tree carries, on npm's release
+# schedule rather than ours.
+#
+# The runtime does not use npm. CMD is `node dist/src/app.js`, HEALTHCHECK is
+# `node -e`, and every dependency is copied pre-installed from the builder
+# stage. The `npm:` strings in AddonsManager are a source *label* for addons
+# resolved under node_modules, not a shell-out. Nothing in docker-compose, the
+# k8s manifests or the deploy scripts execs npm inside the container.
+#
+# So npm is dead weight that only contributes vulnerable files to scans. Deleting
+# it removes this entire class of finding permanently instead of re-triaging it
+# every time npm's vendored tree falls behind.
+#
+# Tradeoff: `docker exec <container> npm ...` no longer works. That was never a
+# supported flow — the image is a runtime, not a build environment — but it is a
+# real behaviour change for anyone who relied on it. Reinstate with
+# `npm install -g npm@12` in a derived image if genuinely needed.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm \
+           /usr/local/bin/npx \
+    && rm -rf /root/.npm /root/.npmrc 2>/dev/null || true
 
 # Copy production node_modules from builder
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
For #956.

## The recorded remedy had already been applied, and stopped working

#956 said: *"bump the base image so its bundled npm carries patched deps."* That was already done — **#859 added `npm install -g npm@12` to the runtime stage for exactly this reason.**

I checked what npm actually bundles rather than trusting its declared ranges. Pulled the published `npm@12.0.1` tarball (the latest release) and read the versions:

```text
tar              7.5.19    vulnerable <= 7.5.20,  patched 7.5.21
brace-expansion  5.0.7     vulnerable <= 5.0.7,   patched 5.0.8
```

**Both exactly one patch short.** Ranges confirmed against `GHSA-r292-9mhp-454m` and `GHSA-mh99-v99m-4gvg`.

So the strategy is the problem, not the version: chasing npm's vendored tree means carrying whatever CVEs it happens to have, on npm's release schedule rather than ours, and re-triaging the same finding on every scan.

## The runtime never uses npm

```text
CMD          node dist/src/app.js
HEALTHCHECK  node -e ...
deps         copied pre-installed from the builder stage
```

The `npm:` strings in `AddonsManager` are a source **label** for addons resolved under `node_modules`, not a shell-out. Nothing in `docker-compose`, the k8s manifests, or the deploy scripts execs npm inside the container — verified by grep, not memory.

So npm is dead weight whose only contribution is vulnerable files in the scan surface. Removing it eliminates the class permanently rather than deferring it to the next npm release.

The **builder stage is untouched** — it genuinely needs npm, and its layers don't ship.

## Tradeoff

`docker exec <container> npm ...` no longer works. That was never a supported flow — the image is a runtime, not a build environment — but it is a real behaviour change for anyone relying on it. Reinstate with `npm install -g npm@12` in a derived image if needed.

## Not verified by an actual build — please read

I could not build this:

- the Docker daemon isn't running in this environment
- `.github/workflows/docker-build.yml` builds only on `v*` tags or `workflow_dispatch`, so **no PR validates it either**

The change is three `rm -rf` lines and I've checked nothing later in the runtime stage invokes npm, but that is reasoning, not evidence.

**Recommend a `workflow_dispatch` run of Docker Build before the next release tag** — discovering a broken Dockerfile during a release build is a bad way to find out.

Separately worth considering: adding a `pull_request` trigger scoped to `docker/**` so Dockerfile changes are validated before they reach a tag. Happy to do that as its own PR if you want it.
