### PR TITLE
chore(kit): sync to v1.0.0-43-g7cf371c

### DIFF
--- a/.claude/commands/pstatus.md
+++ b/.claude/commands/pstatus.md
@@ -18,10 +18,10 @@ recommends what to do next. It does not start work.
   - `gh api "/repos/{owner}/{repo}/code-scanning/alerts?state=open"` (ignore a 404 — feature off)
   - any other scanner signal available (e.g. GitGuardian)
 - `gh issue list --state open --limit 100 --json number,title,labels`
-- `gh pr list --state open --limit 50 --json number,title,isDraft,mergeStateStatus,createdAt,labels`
+- `gh pr list --state open --limit 50 --json number,title,isDraft,mergeStateStatus,createdAt,labels,body,closingIssuesReferences`
   — `gh issue list` does **not** return PRs, so without this they are invisible to every band
   below. A merge-ready security PR can sit open across repeated `/pstatus` runs and never be
-  mentioned once.
+  mentioned once. `closingIssuesReferences` and `body` feed the PR ↔ issue linkage in Step 4.
 - `git log --oneline -5`
 - Read the last entries of `private/project_log.md` for session continuity.
 
@@ -45,9 +45,15 @@ For each open Dependabot / code-scanning / GitGuardian alert:
 
 ### Step 4: Rank and regenerate `TODO.md`
 
-Overwrite `TODO.md` with the open issues grouped into bands. The `▶ Resume here` pointer is owned by
-`/wrap` (written at session end) — `/pstatus` does not write or preserve it; once you've resumed it
-has served its purpose, so regenerating a bands-only `TODO.md` here is expected:
+Overwrite `TODO.md` with the open issues grouped into bands.
+
+**Remove the `▶ Resume here` block, including its `RESUME:START` / `RESUME:END` markers.** The
+pointer is written by `/wrap` at session end and read by `/context` at session open; by the time
+`/pstatus` runs you have already resumed, so it has served its purpose. The output of this step is a
+bands-only `TODO.md` — that is intended, not a loss. `/pstatus` never reads the block and never
+preserves it.
+
+The bands, in this order:
 
 - `🔴 P0 — Security & Critical` (list `security` / vulnerability issues first)
 - `🟠 P1`
@@ -68,9 +74,33 @@ issues, no bare `#<num>`. Each line:
 
 `- [#<num>](https://github.com/{owner}/{repo}/issues/<num>) — <title>`
 
-PRs use the same one-per-line rule with the `/pull/` path:
+PRs use the same one-per-line rule with the `/pull/` path, and **must name their related issues**:
 
-`- [#<num>](https://github.com/{owner}/{repo}/pull/<num>) — <title> *(ready | draft | conflicted)*`
+`- [#<num>](https://github.com/{owner}/{repo}/pull/<num>) — <title> *(ready | draft | conflicted)* — closes [#<n>](…/issues/<n>)`
+
+#### Resolving a PR's related issues
+
+A PR shown without its issue context reads as unrelated housekeeping, so resolve the link for every
+PR in the band. In order:
+
+1. **Declared** — `closingIssuesReferences` from Step 1. These are the issues GitHub will
+   auto-close on merge; render them as `closes #<n>`.
+2. **Mentioned** — any `#<n>` in the PR body that is not a closing reference; render as `refs #<n>`.
+3. **Inferred** — for a dependency-bump PR with neither, match the package name against open
+   `security` issue titles and bodies (including the `scanner-alert:` markers from Step 2). A
+   Dependabot PR bumping package `X` and a tracking issue for an advisory in `X` are the same work
+   arriving from two directions. Render as `likely #<n>` — never as `closes`, since it is a guess.
+
+If none of the three resolve, write `no linked issue` explicitly rather than leaving the line bare.
+A silent absence is indistinguishable from "not checked".
+
+Cross-reference both ways: an issue whose fix is already sitting in an open PR is **not** actually
+open work. Annotate it in its own priority band as `— PR open: [#<pr>](…/pull/<pr>)` so the ranking
+does not recommend starting something that is already written.
+
+Where a PR turns out to be redundant — the change is already on the default branch, or a tracking
+issue was resolved another way — say so on the PR line as `*(redundant — already on <branch>)*`.
+Stale dependency PRs routinely outlive the fix that superseded them.
 
 ### Step 5: Brief the user
 
@@ -80,6 +110,9 @@ P0 (else the top P1, and so on) with one line of why. Stop. Do not begin the wor
 A **merge-ready PR outranks starting new work** when it carries a security fix or a dependency
 bump: it is finished work sitting one click from shipping, so leaving it open while beginning
 something else is strictly worse than merging it first.
+
+State the PR ↔ issue linkage in the recommendation itself. "Merge #24 — it closes P0 #25" is
+actionable; "merge #24" alone makes the operator go look up why it matters.
 
 ## `/pstatus --all` (portfolio sweep — read-only, no writes)
 

--- a/.claude/commands/wrap.md
+++ b/.claude/commands/wrap.md
@@ -71,5 +71,8 @@ Report one clear verdict:
 ## Notes
 
 - `/wrap` is the close bookend to `/context` (open) and complements `/session-commit` (per-chunk).
-- `/context` and `/pstatus` read the `▶ Resume here` block at the top of `TODO.md` first to restore
-  continuity. The dated session history stays in `private/project_log.md`.
+- `/context` reads the `▶ Resume here` block at the top of `TODO.md` first to restore continuity.
+  `/pstatus` does **not** read it — it removes the block when it regenerates the bands. So the
+  block survives exactly one hop: `/wrap` writes it, the next session's `/context` reads it, the
+  first `/pstatus` of that session clears it. Open a session with `/context`, not `/pstatus`, or
+  the pointer is discarded unread. The dated session history stays in `private/project_log.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,10 @@ agent_priority_level: "medium"
 blockers: []
 requires_human_review: ["major architectural changes", "security policy modifications", "deployment to production"]
 agent_autonomy_level: "high"
-kit_version: "v1.0.0-26-gc0e965b"
+kit_version: "v1.0.0-43-g7cf371c"
 ---
 
-<!-- KIT:START v1.0.0-26-gc0e965b — managed by mjs-project-template; edit below the KIT:END marker -->
+<!-- KIT:START v1.0.0-43-g7cf371c — managed by mjs-project-template; edit below the KIT:END marker -->
 # Agent Context & Protocols
 
 This section is **managed by the kit** (`install-kit.sh`) — it is identical across repos. Put repo-specific context **below the `KIT:END` marker**; do not edit here.


### PR DESCRIPTION
Automated kit sync from [mjs-project-template](https://github.com/jwilleke/mjs-project-template), applied by `install-kit.sh`.

Kit version: `v1.0.0-43-g7cf371c`

## Files changed

```text
  M	.claude/commands/pstatus.md
  M	.claude/commands/wrap.md
  M	AGENTS.md
```

Canonical kit files are overwritten wholesale; your own content is untouched. `AGENTS.md` changes
are confined to the managed block between the `KIT:START` / `KIT:END` markers.

Merging when CI is green is the expected path. If a change here is wrong, fix it upstream in the
template rather than in this repo — the next sync would overwrite a local fix.