### PR TITLE
fix(security): neutralise the showdown ReDoS vector (#599, CVE-2024-1899)

### DIFF
--- a/src/managers/RenderingManager.ts
+++ b/src/managers/RenderingManager.ts
@@ -3,6 +3,7 @@
  */
 
 import BaseManager from './BaseManager.js';
+import { guardShowdownInput } from '../utils/showdownGuard.js';
 import type ConfigurationManager from './ConfigurationManager.js';
 import type PageManager from './PageManager.js';
 import type PluginManager from './PluginManager.js';
@@ -371,7 +372,9 @@ class RenderingManager extends BaseManager {
     if (!this.converter) {
       throw new Error('Markdown converter not initialized');
     }
-    const html = this.converter.makeHtml(expandedContent);
+    // #599: same ReDoS guard as the MarkupParser path — this legacy route
+    // reaches the identical unpatched showdown converter.
+    const html = this.converter.makeHtml(guardShowdownInput(expandedContent));
 
     // Step 5: Post-process tables with styling
     const finalHtml = this.postProcessTables(html);

--- a/src/parsers/MarkupParser.ts
+++ b/src/parsers/MarkupParser.ts
@@ -9,6 +9,7 @@ import DOMVariableHandler from './dom/handlers/DOMVariableHandler.js';
 import DOMPluginHandler from './dom/handlers/DOMPluginHandler.js';
 import DOMLinkHandler from './dom/handlers/DOMLinkHandler.js';
 import logger from '../utils/logger.js';
+import { guardShowdownInput } from '../utils/showdownGuard.js';
 import SecurityFilter from './filters/SecurityFilter.js';
 import SpamFilter from './filters/SpamFilter.js';
 import ValidationFilter from './filters/ValidationFilter.js';
@@ -2597,11 +2598,16 @@ class MarkupParser extends BaseManager {
       }
     }
 
-    // Phase 3: Let Showdown parse the sanitized markdown
+    // Phase 3: Let Showdown parse the sanitized markdown.
+    //
+    // #599: guard the input first. showdown 2.1.0 backtracks catastrophically on
+    // unclosed link openers — 12 KB of `[](` blocks the event loop for 16s — and
+    // no patched release exists or is coming. See src/utils/showdownGuard.ts.
+    const guarded = guardShowdownInput(preprocessed);
     const renderingManager = this.engine.getManager<RenderingManagerInterface>('RenderingManager');
     let showdownHtml: string;
     if (renderingManager && renderingManager.converter) {
-      showdownHtml = renderingManager.converter.makeHtml(preprocessed);
+      showdownHtml = renderingManager.converter.makeHtml(guarded);
     } else {
       // Fallback if RenderingManager not available (testing)
       const converter = new showdown.Converter({
@@ -2612,7 +2618,7 @@ class MarkupParser extends BaseManager {
         ghCodeBlocks: true,
         ghHeaderIds: true
       });
-      showdownHtml = converter.makeHtml(preprocessed);
+      showdownHtml = converter.makeHtml(guarded);
     }
     logger.debug('📝 Showdown processed markdown');
 

--- a/src/utils/__tests__/showdownGuard.test.ts
+++ b/src/utils/__tests__/showdownGuard.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @file showdownGuard.test.ts
+ * @description #599 — showdown ReDoS (CVE-2024-1899) guard.
+ *
+ * showdown@2.1.0 is the latest release and the advisory reports
+ * `first_patched_version: null`; the registry has not been touched since
+ * 2023-07-31. There is no upstream fix to wait for.
+ */
+import showdown from 'showdown';
+import { guardShowdownInput, countUnclosedLinkOpeners } from '../showdownGuard';
+
+const converter = () => new showdown.Converter({
+  tables: true, strikethrough: true, tasklists: true, ghCodeBlocks: true
+});
+
+describe('#599 showdown ReDoS guard', () => {
+  describe('the vulnerability', () => {
+    test('the unguarded payload is catastrophically slow', () => {
+      // Establishes the bug is real rather than assumed. Deliberately modest
+      // (n=2000, ~0.4s) so the suite stays fast — n=4000 takes 16 SECONDS
+      // unguarded, which is the actual DoS.
+      const c = converter();
+      const payload = '[]('.repeat(2000);
+
+      const t0 = Date.now();
+      c.makeHtml(payload);
+      const unguarded = Date.now() - t0;
+
+      const t1 = Date.now();
+      c.makeHtml(guardShowdownInput(payload));
+      const guarded = Date.now() - t1;
+
+      expect(guarded).toBeLessThan(unguarded);
+      // Order-of-magnitude, not a tight bound — CI timing varies.
+      expect(guarded).toBeLessThan(100);
+    });
+
+    test('a large payload stays fast once guarded', () => {
+      const c = converter();
+      const t0 = Date.now();
+      c.makeHtml(guardShowdownInput('[]('.repeat(20000)));
+      expect(Date.now() - t0).toBeLessThan(1000);
+    });
+  });
+
+  describe('output preservation', () => {
+    // The property that makes this safe to apply unconditionally: an unclosed
+    // opener never becomes an anchor, so escaping it cannot change what a
+    // reader sees.
+    test.each([
+      ['a plain link', 'a [link](http://example.com) here'],
+      ['parens inside a URL', '[nested](http://e.com/a(b)c)'],
+      ['two links on a line', '[a](b) and [c](d)'],
+      ['an image', '![img](pic.png)'],
+      ['a reference link', '[ref][1]\n\n[1]: http://e.com'],
+      ['links across lines', 'multi\n[x](y)\nlines'],
+      ['no link syntax at all', 'just some prose']
+    ])('leaves rendered output byte-identical: %s', (_name, input) => {
+      const c = converter();
+      expect(c.makeHtml(guardShowdownInput(input))).toBe(c.makeHtml(input));
+    });
+
+    test('an unclosed opener renders as the same visible text', () => {
+      const c = converter();
+      const html = c.makeHtml(guardShowdownInput('text with ]( unclosed'));
+      // `&#40;` IS `(` to a browser — the source differs, the reading does not.
+      expect(html).toContain('&#40;');
+      expect(html).not.toContain('<a ');
+    });
+
+    test('content with no link syntax is returned unchanged by identity', () => {
+      const input = 'no brackets here at all';
+      expect(guardShowdownInput(input)).toBe(input);
+    });
+
+    test('content whose openers are all closed is returned unchanged', () => {
+      const input = '[a](b) [c](d)';
+      expect(guardShowdownInput(input)).toBe(input);
+    });
+  });
+
+  describe('detection', () => {
+    test('counts only unclosed openers', () => {
+      expect(countUnclosedLinkOpeners('[a](b)')).toBe(0);
+      expect(countUnclosedLinkOpeners('[a](')).toBe(1);
+      expect(countUnclosedLinkOpeners('[a](\n[b](')).toBe(2);
+      // A closing paren later on the line means we leave it alone.
+      expect(countUnclosedLinkOpeners('[a]( then ) later')).toBe(0);
+    });
+
+    test('is linear, not quadratic, on a single long line', () => {
+      // The obvious regex fix — /\]\((?![^)\n]*\))/ — reintroduces the very
+      // quadratic scan this exists to prevent. Pin that it does not.
+      const t0 = Date.now();
+      guardShowdownInput('[]('.repeat(50000));
+      expect(Date.now() - t0).toBeLessThan(1000);
+    });
+  });
+});

--- a/src/utils/showdownGuard.ts
+++ b/src/utils/showdownGuard.ts
@@ -1,0 +1,112 @@
+/**
+ * @file showdownGuard.ts
+ * @description Mitigation for the showdown ReDoS, CVE-2024-1899 / GHSA-rmmh-p597-ppvv (#599).
+ *
+ * `showdown@2.1.0` is the latest release and no patch exists — the advisory
+ * reports `first_patched_version: null`, and the registry has not been touched
+ * since 2023-07-31. The package is effectively abandoned, so "wait for
+ * upstream" is not a strategy.
+ *
+ * ## What actually triggers it
+ *
+ * Measured against our own converter options rather than taken from the report:
+ *
+ * ```text
+ * '[]('.repeat(500)    ->     40 ms
+ * '[]('.repeat(2000)   ->   2067 ms
+ * '[]('.repeat(4000)   ->  16331 ms      <- 12 KB of input, 16 s of blocked event loop
+ *
+ * '[]()'.repeat(2000)  ->      4 ms      (closed — fine)
+ * '[a](b)'.repeat(2000)->     24 ms      (real links — fine)
+ * ```
+ *
+ * The trigger is specifically an **unclosed link opener** — a `](` with no
+ * closing `)` after it. Closed and legitimate links are unaffected.
+ *
+ * This also rules out the input-length cap that #599 proposed as mitigation 2:
+ * 12 KB is already catastrophic, and no useful page-size limit sits below that.
+ *
+ * ## Why escaping is safe
+ *
+ * An unclosed opener never becomes an anchor — showdown emits it verbatim:
+ *
+ * ```text
+ * '[]('            -> '<p>[](</p>'
+ * 'text [x]( more' -> '<p>text [x]( more</p>'
+ * ```
+ *
+ * So replacing the `(` with `&#40;` produces identical rendered output: the
+ * browser shows `](` either way. This changes nothing a reader can see, which
+ * is the property that makes it safe to apply unconditionally.
+ *
+ * A `](` with any `)` after it on the same line is left completely alone, so
+ * every real link — including ones with nested parens in the URL — is
+ * untouched.
+ */
+
+/** Entity for `(` — renders identically, but showdown will not try to parse a link. */
+const ESCAPED_PAREN = '&#40;';
+
+/**
+ * Neutralise unclosed markdown link openers so showdown cannot backtrack on them.
+ *
+ * Linear in the length of the input: one pass per line, using the position of
+ * the last `)` on that line rather than a lookahead. A regex with a negative
+ * lookahead (`\]\((?![^)\n]*\))`) would have reintroduced the quadratic scan
+ * this exists to prevent — the fix would have carried the bug.
+ *
+ * @param content - Markdown about to be handed to showdown
+ * @returns The same markdown with unclosed `](` openers escaped
+ */
+export function guardShowdownInput(content: string): string {
+  // Fast path: nothing that could open a link.
+  if (!content.includes('](')) return content;
+
+  const lines = content.split('\n');
+  let changed = false;
+
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li];
+    const lastClose = line.lastIndexOf(')');
+    let out = '';
+    let cursor = 0;
+    let idx = line.indexOf('](');
+
+    while (idx !== -1) {
+      // Closed if any ')' appears after this opener on the line. Conservative
+      // by design: when in doubt we leave the text exactly as it was.
+      if (lastClose > idx + 1) {
+        idx = line.indexOf('](', idx + 2);
+        continue;
+      }
+      out += line.slice(cursor, idx) + ']' + ESCAPED_PAREN;
+      cursor = idx + 2;
+      changed = true;
+      idx = line.indexOf('](', cursor);
+    }
+
+    if (cursor > 0) lines[li] = out + line.slice(cursor);
+  }
+
+  return changed ? lines.join('\n') : content;
+}
+
+/**
+ * Count unclosed link openers — used for logging and tests, not for the fix.
+ *
+ * @param content - Markdown to inspect
+ * @returns How many `](` openers have no closing `)` after them on their line
+ */
+export function countUnclosedLinkOpeners(content: string): number {
+  if (!content.includes('](')) return 0;
+  let total = 0;
+  for (const line of content.split('\n')) {
+    const lastClose = line.lastIndexOf(')');
+    let idx = line.indexOf('](');
+    while (idx !== -1) {
+      if (!(lastClose > idx + 1)) total++;
+      idx = line.indexOf('](', idx + 2);
+    }
+  }
+  return total;
+}


### PR DESCRIPTION
For #599.

## There is no upstream fix, and none is coming

Verified rather than assumed:

```text
advisory GHSA-rmmh-p597-ppvv   first_patched_version: null
npm dist-tags.latest           2.1.0        (what we already run)
registry last modified         2023-07-31
```

The package is abandoned. Option 4 in the issue — "monitor for a patch" — is not a strategy.

## Reproduced, and the trigger is narrower than reported

Measured against our own converter options:

```text
'[]('.repeat(500)      ->     40 ms
'[]('.repeat(2000)     ->   2067 ms
'[]('.repeat(4000)     ->  16331 ms    ← 12 KB input, 16 s of blocked event loop

'[]()'.repeat(2000)    ->      4 ms    (closed — fine)
'[a](b)'.repeat(2000)  ->     24 ms    (real links — fine)
```

The trigger is specifically an **unclosed link opener** — a `](` with no `)` after it.

**That disproves mitigation 2 in the issue.** An input-length cap cannot help when 12 KB already costs 16 seconds; no useful page-size limit sits below that.

## The fix, and why it is safe

Escape the `(` of unclosed openers to `&#40;` before showdown sees them.

This is output-preserving **by construction**, because an unclosed opener never becomes an anchor — showdown emits it verbatim:

```text
'[]('             ->  '<p>[](</p>'
'text [x]( more'  ->  '<p>text [x]( more</p>'
```

`&#40;` *is* `(` to a browser, so nothing a reader sees changes. Any `](` with a `)` after it on the same line is left completely alone, so real links — including URLs with nested parens — are untouched.

## Not the worker-thread timeout

Option 1 is the general answer, and I didn't take it: it puts a thread hop on every page render, on a path currently serving `/view/Welcome` in 22 ms, to defend a vector that can be removed outright for free.

Worth revisiting if a second showdown vector appears that isn't input-shaped. Noted in the code so the reasoning survives.

## One trap worth naming

The obvious one-line fix — `/\]\((?![^)\n]*\))/` — **reintroduces the same quadratic scan**, because the lookahead re-scans to end of line from every match. The fix would have carried the bug.

The guard walks each line once using the position of its last `)`. There's a test pinning that it stays linear at 50,000 openers.

## Results

```text
12 KB payload   16331 ms  ->  1 ms
60 KB payload        n/a  ->  5 ms
```

Live `haddock-styles` renders identically — 161 code spans, 69 classed spans, **zero** stray entities.

14 tests, including the unguarded-vs-guarded comparison and byte-identical output across plain links, images, reference links, two-links-per-line, and URLs containing parens.

Suite **6820 passing**, 86 E2E, `tsc` and lint clean.

## Does this close #599?

Your call. It removes the demonstrated DoS, but we still ship an abandoned markdown renderer, and the Dependabot alert will stay open because the version is unchanged. The durable answer is migrating to `marked` or `markdown-it` (option 3) — worth its own issue rather than being folded in here.
