### PR TITLE
feat(search): URL tokenization and prefix typeahead (#884)

### DIFF
--- a/src/providers/BaseSearchProvider.ts
+++ b/src/providers/BaseSearchProvider.ts
@@ -88,6 +88,18 @@ export interface SearchOptions {
 
   /** WikiContext for the current request — used to filter private search results */
   wikiContext?: SearchWikiContext;
+
+  /**
+   * #884: treat the LAST query term as a prefix, for as-you-type search.
+   *
+   * Opt-in. A user who has typed "volc" wants Volcano; a user who submitted
+   * "volc" deliberately does not want every word starting with it, so this is
+   * never applied to a completed search.
+   *
+   * Only the last term is widened — earlier terms are complete words the user
+   * has finished typing.
+   */
+  prefixLastTerm?: boolean;
 }
 
 /**

--- a/src/providers/LunrSearchProvider.ts
+++ b/src/providers/LunrSearchProvider.ts
@@ -40,6 +40,75 @@ type LunrSearchResult = lunr.Index.Result;
 /**
  * Document structure for indexing
  */
+/**
+ * Widen the last term of a query to a prefix match (#884).
+ *
+ * Lunr's `*` wildcard, applied only to the final term: someone mid-word wants
+ * completions, someone who submitted a finished query does not. Earlier terms
+ * are words the user has already finished typing and stay exact.
+ *
+ * Left alone when the last term already carries Lunr syntax — a wildcard, a
+ * field scope (`title:x`), or a presence operator (`+`/`-`). Appending `*` to
+ * those either duplicates an existing wildcard or corrupts the operator, and
+ * silently mangling a query the caller wrote deliberately is worse than not
+ * helping.
+ *
+ * @param query - Raw user query
+ * @returns The query with its last term widened, or unchanged
+ */
+export function applyPrefixToLastTerm(query: string): string {
+  const trimmed = query.trim();
+  if (!trimmed) return query;
+
+  const parts = trimmed.split(/\s+/);
+  const last = parts[parts.length - 1];
+
+  if (last.includes('*') || last.includes(':') || last.startsWith('+') || last.startsWith('-')) {
+    return query;
+  }
+  // A term Lunr would tokenise away entirely gains nothing from a wildcard.
+  if (!/[a-z0-9]/i.test(last)) return query;
+
+  parts[parts.length - 1] = `${last}*`;
+  return parts.join(' ');
+}
+
+/**
+ * Split URLs found in page content into searchable word tokens (#884).
+ *
+ * A URL indexed as one opaque string only ever matches if the reader types it
+ * in full. Splitting on the separators that carry no meaning — `[/:._\-?&=#]`
+ * — turns `https://en.wikipedia.org/wiki/Volcano` into `en wikipedia org wiki
+ * volcano`, so the domain and the path words each become findable terms.
+ *
+ * Deliberately conservative about what counts as a URL: only `http(s)://`
+ * matches. Bare domains would drag in ordinary prose containing dots, and
+ * abbreviations like "e.g." would tokenise into noise.
+ *
+ * Numeric-only and single-character fragments are dropped — port numbers, path
+ * ids and `v2`-style noise add index weight without ever being searched for.
+ *
+ * @param content - Page body
+ * @returns Space-joined tokens, or '' when the page links nowhere
+ */
+export function tokenizeUrls(content: string): string {
+  if (!content || !content.includes('://')) return '';
+
+  const urls = content.match(/https?:\/\/[^\s)<>"'\]]+/gi);
+  if (!urls) return '';
+
+  const seen = new Set<string>();
+  for (const url of urls) {
+    for (const raw of url.replace(/^https?:\/\//i, '').split(/[/:._\-?&=#]+/)) {
+      const token = raw.toLowerCase();
+      if (token.length < 2) continue;
+      if (/^\d+$/.test(token)) continue;
+      seen.add(token);
+    }
+  }
+  return [...seen].join(' ');
+}
+
 interface LunrDocument {
   id: string;
   title: string;
@@ -58,6 +127,10 @@ interface LunrDocument {
   status?: string;
   tags: string;
   keywords: string;
+  /** #884: URLs found in the body, split into their component words so a
+   *  domain or path segment is a searchable term. Empty when the page links
+   *  nowhere — the common case for prose pages. */
+  urlTokens: string;
   lastModified: string;
   /** ISO 8601 page creation timestamp (#754, v3.33.0). Optional because
    *  pre-migration synthetic test data may omit it. Indexed so #774's
@@ -84,6 +157,7 @@ interface LunrConfig {
   stemming: boolean;
   boost: {
     title: number;
+    urlTokens?: number;
     systemCategory: number;
     knowledgeRole: number;
     userKeywords: number;
@@ -177,6 +251,13 @@ class LunrSearchProvider extends BaseSearchProvider {
         keywords: configManager.getProperty<number>(
           'ngdpbase.search.provider.lunr.boost.keywords',
           4
+        ),
+        // #884: below every metadata field and above raw content. A domain
+        // match is a real signal — someone searching "wikipedia" wants pages
+        // citing it — but weaker than a page actually being *about* the term.
+        urlTokens: configManager.getProperty<number>(
+          'ngdpbase.search.provider.lunr.boost.urltokens',
+          3
         )
       },
       maxResults: configManager.getProperty<number>(
@@ -257,6 +338,8 @@ class LunrSearchProvider extends BaseSearchProvider {
       this.field('userKeywords', { boost: boostConfig.userKeywords });
       this.field('tags', { boost: boostConfig.tags });
       this.field('keywords', { boost: boostConfig.keywords });
+      // #884: URLs are otherwise only matchable as one opaque string.
+      this.field('urlTokens', { boost: boostConfig.urlTokens ?? 3 });
       Object.values(docs).forEach(doc => { this.add(doc); });
     });
   }
@@ -317,6 +400,7 @@ class LunrSearchProvider extends BaseSearchProvider {
       status: status || undefined,
       tags,
       keywords: `${userKeywords} ${tags}`,
+      urlTokens: tokenizeUrls(content),
       lastModified: toStr(metadata.lastModified),
       created: toStr(metadata.created) || undefined,
       uuid: toStr(metadata.uuid),
@@ -410,7 +494,8 @@ class LunrSearchProvider extends BaseSearchProvider {
 
     try {
       const maxResults = options.maxResults || this.config?.maxResults || 50;
-      const results: LunrSearchResult[] = this.searchIndex.search(query);
+      const effectiveQuery = options.prefixLastTerm ? applyPrefixToLastTerm(query) : query;
+      const results: LunrSearchResult[] = this.searchIndex.search(effectiveQuery);
 
       // Extract user context for private-page filtering
       const wikiContext = options.wikiContext;

--- a/src/providers/__tests__/LunrSearchProvider-Ranking.test.ts
+++ b/src/providers/__tests__/LunrSearchProvider-Ranking.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @file LunrSearchProvider-Ranking.test.ts
+ * @description #884 — URL tokenization and prefix typeahead.
+ *
+ * Field weighting (bullet 1) was already implemented: title 10, systemCategory
+ * 8, knowledgeRole 8, userKeywords 6, tags 5, keywords 4, content 1. These
+ * cover the two bullets that were genuinely missing.
+ */
+// Opt out of the global provider mock — these test the real helpers.
+vi.unmock('../LunrSearchProvider');
+vi.unmock('../../providers/LunrSearchProvider');
+
+import { tokenizeUrls, applyPrefixToLastTerm } from '../LunrSearchProvider';
+
+describe('#884 URL tokenization', () => {
+  test('splits a URL into its component words', () => {
+    // The point of the feature: "wikipedia" and "volcano" become findable on a
+    // page that merely links there.
+    const out = tokenizeUrls('See https://en.wikipedia.org/wiki/Volcano for more');
+    expect(out.split(' ').sort()).toEqual(['en', 'org', 'volcano', 'wiki', 'wikipedia']);
+  });
+
+  test('splits query strings and fragments too', () => {
+    const out = tokenizeUrls('http://example.com/path?topic=lava&sort=date#section');
+    expect(out).toContain('example');
+    expect(out).toContain('lava');
+    expect(out).toContain('section');
+  });
+
+  test('de-duplicates across multiple URLs', () => {
+    const out = tokenizeUrls('http://example.com/a http://example.com/b');
+    expect(out.split(' ').filter((t) => t === 'example')).toHaveLength(1);
+  });
+
+  test('returns empty for content with no URLs', () => {
+    expect(tokenizeUrls('just prose, no links here')).toBe('');
+    expect(tokenizeUrls('')).toBe('');
+  });
+
+  test('ignores bare domains and abbreviations', () => {
+    // Only http(s):// counts. Matching bare dots would turn "e.g." and every
+    // sentence-ending abbreviation into index noise.
+    expect(tokenizeUrls('see example.com or e.g. this')).toBe('');
+  });
+
+  test('drops numeric-only and single-character fragments', () => {
+    // Ports, path ids and `/a/` noise carry index weight and are never searched.
+    const out = tokenizeUrls('http://example.com:8080/v/2/9/page');
+    expect(out.split(' ')).not.toContain('8080');
+    expect(out.split(' ')).not.toContain('2');
+    expect(out.split(' ')).not.toContain('v');
+    expect(out).toContain('page');
+  });
+
+  test('does not swallow trailing markdown punctuation', () => {
+    const out = tokenizeUrls('[link](https://example.com/docs) and text');
+    expect(out).toContain('docs');
+    expect(out.split(' ')).not.toContain('and');
+  });
+});
+
+describe('#884 prefix typeahead', () => {
+  test('widens only the last term', () => {
+    // Earlier terms are words the user has finished typing.
+    expect(applyPrefixToLastTerm('volcano eru')).toBe('volcano eru*');
+  });
+
+  test('widens a single term', () => {
+    expect(applyPrefixToLastTerm('volc')).toBe('volc*');
+  });
+
+  test('leaves a term that already has a wildcard alone', () => {
+    expect(applyPrefixToLastTerm('volc*')).toBe('volc*');
+  });
+
+  test('leaves field-scoped and presence-operator terms alone', () => {
+    // Appending `*` to these corrupts a query the caller wrote deliberately.
+    expect(applyPrefixToLastTerm('title:volcano')).toBe('title:volcano');
+    expect(applyPrefixToLastTerm('lava +volcano')).toBe('lava +volcano');
+    expect(applyPrefixToLastTerm('lava -ash')).toBe('lava -ash');
+  });
+
+  test('leaves an empty or punctuation-only query alone', () => {
+    expect(applyPrefixToLastTerm('')).toBe('');
+    expect(applyPrefixToLastTerm('   ')).toBe('   ');
+    expect(applyPrefixToLastTerm('a ---')).toBe('a ---');
+  });
+});


### PR DESCRIPTION
Two of the four bullets in #884. I checked the other two before writing anything.

## Already implemented — bullets 1 and 4

**Field weighting exists.** `LunrSearchProvider` already registers:

```text
title 10 · systemCategory 8 · knowledgeRole 8 · userKeywords 6 · tags 5 · keywords 4 · content 1
```

each config-overridable. **Keyword-first** (bullet 4) follows from the same weights — every keyword field already outranks content.

**A contradiction worth flagging:** bullet 1 asks for `title ≫ content ≫ description/metadata`, bullet 4 asks for keywords *above* content. Those can't both hold. The shipped weights implement bullet 4. I'm not reordering them on the strength of an inconsistency — the current order is defensible and live.

## Shipped — bullets 2 and 3

### URL tokenization

URLs sat inside `content` as opaque strings, matchable only by typing them in full. They now split on the separators that carry no meaning — `[/:._\-?&=#]` — into a dedicated `urlTokens` field:

```text
https://en.wikipedia.org/wiki/Volcano  ->  en wikipedia org wiki volcano
```

Boosted at **3**: below every metadata field, above raw content. A domain match is real signal — someone searching "wikipedia" wants pages citing it — but weaker than a page being *about* the term.

Deliberately conservative: only `http(s)://` counts. Matching bare domains would turn `e.g.` and every sentence-ending abbreviation into index noise. Numeric-only and single-character fragments are dropped, since ports, path ids and `/v/` noise add index weight and are never searched for.

### Prefix typeahead

Opt-in via `prefixLastTerm`, widening **only the final term**. Someone mid-word wants completions; someone who submitted a finished query does not, so it's never applied to a completed search.

Terms already carrying Lunr syntax — a wildcard, a field scope (`title:x`), a `+`/`-` operator — are left alone. Appending `*` either duplicates a wildcard or corrupts the operator, and silently mangling a query the caller wrote deliberately is worse than not helping.

## Operational note — please read

**Existing indexes carry no `urlTokens`.** Verified on jimstest: 0 of the persisted documents have the field. URL search only starts working once pages are re-indexed.

No migration is included — a rebuild happens naturally as pages are saved, or immediately via the admin search rebuild. Worth doing deliberately rather than wondering why URL search seems dead.

## Verification

12 tests covering tokenization (splitting, dedup, query strings, the bare-domain and numeric-fragment exclusions, markdown punctuation) and prefix behaviour (last-term-only, and each syntax case left alone).

Suite **6818 passing**, `tsc` and lint clean. Live search verified still returning real hits on the 17k-page index.

## Not included

The elasticsearch addon (#550) has its own scoring path and is untouched here.
