### PR TITLE
fix(docker): publish an npm-capable -devtools variant for derived builds (#1001)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -96,6 +96,10 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/amd64
+          # MUST be explicit. The Dockerfile's last stage is `devtools`, which
+          # retains npm — an untargeted build would silently publish that as the
+          # deployed image and undo #956 (#1001).
+          target: runtime
           push: ${{ github.event_name != 'pull_request' }}
           load: true
           tags: ${{ github.event_name == 'pull_request' && steps.img.outputs.ref || steps.meta.outputs.tags }}
@@ -167,6 +171,19 @@ jobs:
         if: always()
         run: docker rm -f ngdpbase-smoke 2>/dev/null || true
 
+      # #1001: assert the runtime image really has no npm. #956 removed it and
+      # nothing checked, so a later edit could put it back unnoticed — and the
+      # inverse (an untargeted build shipping the devtools stage) is exactly the
+      # failure this pair of assertions exists to catch.
+      - name: Assert runtime image has no npm
+        run: |
+          if docker run --rm --entrypoint sh ${{ steps.img.outputs.ref }} \
+               -c 'command -v npm || command -v npx' 2>/dev/null; then
+            echo "FAILED: npm/npx present in the runtime image (#956, #1001)."
+            exit 1
+          fi
+          echo "Runtime image has no npm/npx, as expected."
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
@@ -188,6 +205,87 @@ jobs:
           # under refs/tags/v* never auto-closes master alerts (#878).
           ref: refs/heads/master
           sha: ${{ github.sha }}
+
+      # =====================================================================
+      # Devtools variant (#1001)
+      # =====================================================================
+      # Published as :<version>-devtools. Identical to the runtime image except
+      # npm is retained, for consumers that build FROM ngdpbase and need to
+      # `npm install` an addon into the derived layer — the packaged-addon model
+      # in docs/platform/deployment/addon-packaged.md.
+      #
+      # Deliberately NOT Trivy-uploaded. It carries npm's vendored tree on
+      # purpose, so scanning it would re-open exactly the alerts #956 closed and
+      # then report them against master. It is a build input, never deployed.
+      - name: Docker meta (devtools)
+        id: meta-devtools
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKER_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.DOCKER_IMAGE_NAME }}
+          flavor: |
+            suffix=-devtools,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
+          labels: |
+            org.opencontainers.image.title=ngdpbase-devtools
+            org.opencontainers.image.description=ngdpbase with npm retained — for derived builds only, not for deployment
+            org.opencontainers.image.vendor=ngdpbase Project
+
+      - name: Resolve devtools image reference
+        id: img-devtools
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "ref=${{ env.DOCKER_IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-devtools" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ env.DOCKER_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.DOCKER_IMAGE_NAME }}:latest-devtools" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push devtools image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64
+          target: devtools
+          push: ${{ github.event_name != 'pull_request' }}
+          load: true
+          tags: ${{ github.event_name == 'pull_request' && steps.img-devtools.outputs.ref || steps.meta-devtools.outputs.tags }}
+          labels: ${{ steps.meta-devtools.outputs.labels }}
+          build-args: |
+            NODE_VERSION=${{ env.DOCKER_NODE_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # The regression check that would have caught #1001 before it shipped:
+      # prove the derived-build path actually works, rather than assuming it.
+      - name: Assert devtools image can run npm and build FROM
+        run: |
+          docker run --rm --entrypoint sh ${{ steps.img-devtools.outputs.ref }} \
+            -c 'npm --version && npx --version' \
+            || { echo "FAILED: npm/npx missing from the devtools image (#1001)."; exit 1; }
+
+          # Prove a derived image can install a package — the flow #956 broke.
+          # Empty build context on purpose: nothing is COPYed, and pointing this
+          # at /tmp or the repo root would ship a large context for no reason.
+          CTX="$(mktemp -d)"
+          cat > "$CTX/Dockerfile" <<'EOF'
+          ARG BASE
+          FROM ${BASE}
+          WORKDIR /derived
+          RUN npm install --no-audit --no-fund is-number@7.0.0 \
+              && node -e "require('/derived/node_modules/is-number')"
+          EOF
+          docker build \
+            --build-arg BASE=${{ steps.img-devtools.outputs.ref }} \
+            -t ngdpbase-derived-check "$CTX" \
+            || { echo "FAILED: cannot build FROM the devtools image (#1001)."; exit 1; }
+          docker rmi -f ngdpbase-derived-check 2>/dev/null || true
+          rm -rf "$CTX"
+          echo "Derived-build path verified."
 
       - name: Image digest
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,10 +70,24 @@ RUN apk add --no-cache libstdc++
 # it removes this entire class of finding permanently instead of re-triaging it
 # every time npm's vendored tree falls behind.
 #
-# Tradeoff: `docker exec <container> npm ...` no longer works. That was never a
-# supported flow — the image is a runtime, not a build environment — but it is a
-# real behaviour change for anyone who relied on it. Reinstate with
-# `npm install -g npm@12` in a derived image if genuinely needed.
+# Tradeoff: nothing in THIS image can run npm any more. That covers two flows,
+# and the second one is load-bearing (#1001):
+#
+#   1. `docker exec <container> npm ...` — never a supported flow. The image is
+#      a runtime, not a build environment.
+#   2. Building `FROM ghcr.io/jwilleke/ngdpbase:<version>` and then running
+#      `npm install <addon>` — this IS supported. It is the packaged-addon
+#      deployment model documented in
+#      docs/platform/deployment/addon-packaged.md, and it is how geohazardwatch
+#      is built. #956 broke it, in a patch release, and the break surfaced as a
+#      red release build downstream.
+#
+# Flow 2 is restored by the `devtools` stage below rather than by putting npm
+# back here, so the deployed image still carries none of npm's vendored CVEs.
+# Derived images build FROM the `-devtools` tag instead.
+#
+# (The original note here suggested reinstating with `npm install -g npm@12` in
+# a derived image. That cannot work — there is no npm left to run it with.)
 RUN rm -rf /usr/local/lib/node_modules/npm \
            /usr/local/bin/npm \
            /usr/local/bin/npx \
@@ -159,6 +173,40 @@ VOLUME ["/app/data"]
 # Start command - direct node execution (no PM2)
 # PM2 is removed for K8s compatibility - K8s handles process management
 CMD ["node", "dist/src/app.js"]
+
+# =============================================================================
+# Stage 3: Devtools — build-capable variant, published as :<version>-devtools
+# =============================================================================
+#
+# Identical to `runtime` in every respect except that npm/npx are present.
+# Exists for images built FROM ngdpbase that need to install something into the
+# derived layer — the packaged-addon model (#1001). Not for deployment: it
+# carries npm's vendored dependency tree, which is the whole thing #956 removed.
+#
+# Which tag to use:
+#
+#   ghcr.io/jwilleke/ngdpbase:X.Y.Z            deploy this
+#   ghcr.io/jwilleke/ngdpbase:X.Y.Z-devtools   build FROM this
+#
+# A derived image built FROM `-devtools` inherits npm. If the final artifact is
+# going to be deployed, drop npm again in the derived Dockerfile's last stage
+# with the same `rm -rf` as the runtime stage above.
+#
+# npm is copied from `builder` rather than reinstalled, so the version is
+# exactly the one the base node image shipped — no network fetch, no separate
+# version axis to track.
+FROM runtime AS devtools
+
+COPY --from=builder /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+
+# The node images ship these as relative symlinks into lib/node_modules; recreate
+# them the same way so `npm` and `npx` resolve on PATH.
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && npm --version
+
+LABEL org.opencontainers.image.title="ngdpbase-devtools"
+LABEL org.opencontainers.image.description="ngdpbase with npm retained — for derived builds only, not for deployment"
 
 # =============================================================================
 # Configuration and Installation

--- a/docs/platform/deployment/addon-packaged.md
+++ b/docs/platform/deployment/addon-packaged.md
@@ -106,16 +106,35 @@ Publish is a normal `npm publish` (typically from the addon repo's CI on a versi
 
 ## Deploying
 
-In a generic ngdpbase image (or a thin layer on it):
+In a generic ngdpbase image (or a thin layer on it). **Build FROM the `-devtools` tag** — the plain runtime tag has no npm:
 
 ```dockerfile
-FROM ghcr.io/jwilleke/ngdpbase:3.62.1
+FROM ghcr.io/jwilleke/ngdpbase:3.62.1-devtools
 WORKDIR /app
 RUN npm install @jwilleke/geohazardwatch-addon@1.4.2
 # addons-path includes "node_modules:@jwilleke/*-addon"; enable the addon in config
 ```
 
 Renovate then tracks `@jwilleke/geohazardwatch-addon` against npm semver — the addon version and the ngdpbase base-image version bump **independently**, each lockfile/tag-pinned. No cross-repo build context, no directory drift.
+
+### Which base tag
+
+Two tags are published per release, from the same build:
+
+| Tag | Has npm | Use for |
+|---|---|---|
+| `ghcr.io/jwilleke/ngdpbase:X.Y.Z` | no | **deploying** — this is what runs in production |
+| `ghcr.io/jwilleke/ngdpbase:X.Y.Z-devtools` | yes | **building FROM** — derived images that `npm install` an addon |
+
+npm was removed from the runtime image in [#956](https://github.com/jwilleke/ngdpbase/issues/956) so the deployed artifact carries none of npm's vendored CVEs. That is worth keeping, but it also broke this page's `npm install` step — see [#1001](https://github.com/jwilleke/ngdpbase/issues/1001). The `-devtools` variant restores the build capability without putting npm back into what you deploy.
+
+A derived image built `FROM …-devtools` **inherits npm**, so the addon image you ship carries it too. If that matters for your scan posture, drop it again in the derived Dockerfile's final stage:
+
+```dockerfile
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+```
+
+Renovate tracks the two tags as one version axis — a `-devtools` pin bumps on the same releases as the plain tag.
 
 ## Pages, themes, and everything else
 


### PR DESCRIPTION
Closes #1001.

## Why a PR rather than direct to master

`docker-build.yml` triggers on `pull_request` (paths `docker/**`, the workflow itself) and on `v*` tags — **not** on pushes to master. Landing this directly would get zero validation until the release build, which is the exact failure mode #956 added the PR trigger to prevent. Docker isn't running on the dev machine, so CI is the only place this can be proven.

## What it does

Adds a third stage `devtools`, published as `:<version>-devtools`. Identical to `runtime` except npm/npx are restored by copying from the `builder` stage — no network fetch, no second version axis to track.

| Tag | npm | Use |
|---|---|---|
| `:X.Y.Z` | no | deploy |
| `:X.Y.Z-devtools` | yes | build FROM |

## What to watch in this run

- **`target:` is now explicit on both builds.** The Dockerfile's last stage is `devtools`; an untargeted build would take it and silently publish the npm-carrying image as `:latest`, undoing #956.
- **`Assert runtime image has no npm`** — must pass.
- **`Assert devtools image can run npm and build FROM`** — builds a throwaway derived image that `npm install`s a package. This is the check that would have caught #1001.
- The devtools image is **not** Trivy-uploaded, by design — it carries npm deliberately, so scanning it would re-open the alerts #956 closed.

Nothing is pushed to the registry on a PR run.

## Not in this PR

- The release-classification question — #1001 argues this should go out as **4.0.0**, not a minor. Operator call.
- geohazardwatch's base-tag bump to `-devtools`, which needs a published image first, and lands in that repo as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)