### PR TITLE
chore(docs): stop linting TypeDoc output as prose

### DIFF
--- a/docs/api/generated/.markdownlint-cli2.jsonc
+++ b/docs/api/generated/.markdownlint-cli2.jsonc
@@ -1,0 +1,14 @@
+// TypeDoc output. Generated from source on every `npm run docs:api`, so any fix
+// applied here is discarded by the next run — the source of a fix is the TSDoc
+// comment, not this file.
+//
+// This exemption used to live in the repo's .markdownlintignore. The agent kit
+// moved markdown linting to markdownlint-cli2, which does NOT read that file, so
+// the entry stopped being honoured and five violations surfaced in generated
+// output. A directory-level config is what cli2 does read, and install-kit.sh
+// never writes into subdirectories, so it survives every kit sync.
+{
+  "config": {
+    "default": false
+  }
+}


### PR DESCRIPTION
`Kit Sync` has never opened a pull request in this repo. It applies the sync, then fails its in-job markdown lint and takes the graceful path — filing an issue and reporting green — so the failure was invisible.

All five violations are in `docs/api/generated/`, which `npm run docs:api` regenerates:

```text
docs/api/generated/README.md:1                                    MD036  emphasis as heading
docs/api/generated/src/parsers/LinkParser/README.md:11            MD059  [Link] not descriptive
docs/api/generated/src/providers/VersioningFileProvider/…:632,855 MD033  inline HTML <void>
docs/api/generated/src/utils/VersionCompression/…:193             MD024  duplicate 'Throws'
```

None is fixable at the file — the next `docs:api` run discards it. The source of a fix is the TSDoc comment.

## Why the existing exemption stopped working

This repo already declared it:

```text
# .markdownlintignore
docs/api/generated/**
```

The agent kit moved markdown linting to `markdownlint-cli2` in v1.4.0, and cli2 **does not read `.markdownlintignore`** — it reads `ignores` in its own config. So all nine entries in that file silently stopped being honoured.

That is a kit migration defect and is being handled upstream. This PR is the local half: a directory-level `.markdownlint-cli2.jsonc`, which cli2 does read and which `install-kit.sh` never overwrites because the kit does not write into subdirectories.

The other eight entries in `.markdownlintignore` are not currently producing violations, but they are equally unhonoured — worth reviewing once the upstream warning lands.