### PR TITLE
chore(kit): sync to v1.11.4-5-g17d7aa6

### DIFF
--- a/.agent-kit.json
+++ b/.agent-kit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
   "source": "https://github.com/jwilleke/mjs-project-template",
-  "installed": "v1.11.1",
-  "installed_ref": "v1.11.1-0-g71bbbdf",
+  "installed": "v1.11.4",
+  "installed_ref": "v1.11.4-5-g17d7aa6",
   "installed_at": "2026-08-18",
   "files": {
     ".claude/commands/pstatus.md": { "behavior": "overwrite", "sha256": "d01fc63bde87b183d8d544bedbbfb0d86a76882881d8927d71acf97cba11d0a7" },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,10 @@ agent_priority_level: "medium"
 blockers: []
 requires_human_review: ["major architectural changes", "security policy modifications", "deployment to production"]
 agent_autonomy_level: "high"
-kit_version: "v1.11.1-0-g71bbbdf"
+kit_version: "v1.11.4-5-g17d7aa6"
 ---
 
-<!-- KIT:START v1.11.1-0-g71bbbdf — managed by mjs-project-template; edit below the KIT:END marker -->
+<!-- KIT:START v1.11.4-5-g17d7aa6 — managed by mjs-project-template; edit below the KIT:END marker -->
 ## Agent Kit Protocols
 
 This section is __managed by the kit__ (`install-kit.sh`) — it is identical across repos. Put repo-specific context __below the `KIT:END` marker__; do not edit here.

--- a/required-pages/443c95f1-0b21-494a-b712-08ce0dc933e1.md
+++ b/required-pages/443c95f1-0b21-494a-b712-08ce0dc933e1.md
@@ -99,9 +99,9 @@ Using footnotes provides several benefits:
 
     You can include code blocks, lists, and other markdown elements within footnotes:
 
-    - Item 1
-    - Item 2
-    - Item 3
+- Item 1
+- Item 2
+- Item 3
 
 [^4]: For example: Smith, J. (2024). "Markdown Best Practices." Journal of Documentation, 15(3), 234-256.
 


### PR DESCRIPTION
Automated kit sync from [mjs-project-template](https://github.com/jwilleke/mjs-project-template), applied by `install-kit.sh`.

Kit version: `v1.11.4-5-g17d7aa6`

## Files changed

```text
  M	.agent-kit.json
  M	AGENTS.md
  M	required-pages/443c95f1-0b21-494a-b712-08ce0dc933e1.md
```

Canonical kit files are overwritten wholesale; your own content is untouched. `AGENTS.md` changes
are confined to the managed block between the `KIT:START` / `KIT:END` markers.

Merging when CI is green is the expected path. If a change here is wrong, fix it upstream in the
template rather than in this repo — the next sync would overwrite a local fix.